### PR TITLE
Improvements and Fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,10 +3,6 @@ project(bayesmix)
 
 
 set (CMAKE_CXX_STANDARD 14)
-set(CMAKE_BUILD_TYPE RelWithDebInfo)
-# set(CMAKE_BUILD_TYPE Release)
-
-
 set(CMAKE_CXX_FLAGS_RELEASE "-O3 -march=native -msse2 -funroll-loops -ftree-vectorize -fopenmp")
 
 
@@ -14,8 +10,6 @@ find_package(PkgConfig REQUIRED)
 find_package(OpenMP REQUIRED)
 find_package(Protobuf REQUIRED)
 
-set(CMAKE_CXX_STANDARD 14)
-set(CMAKE_BUILD_TYPE Debug)
 
 set(CMAKE_BUILD_WITH_INSTALL_RPATH ON)
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)

--- a/lib/progressbar/progressbar.hpp
+++ b/lib/progressbar/progressbar.hpp
@@ -1,0 +1,61 @@
+#pragma once
+
+#include <chrono>
+#include <iostream>
+
+namespace progresscpp {
+class ProgressBar {
+ private:
+  unsigned int ticks = 0;
+
+  const unsigned int total_ticks;
+  const unsigned int bar_width;
+  const char complete_char = '=';
+  const char incomplete_char = ' ';
+  const std::chrono::steady_clock::time_point start_time =
+      std::chrono::steady_clock::now();
+
+ public:
+  ProgressBar(unsigned int total, unsigned int width, char complete,
+              char incomplete)
+      : total_ticks{total},
+        bar_width{width},
+        complete_char{complete},
+        incomplete_char{incomplete} {}
+
+  ProgressBar(unsigned int total, unsigned int width)
+      : total_ticks{total}, bar_width{width} {}
+
+  unsigned int operator++() { return ++ticks; }
+
+  void display() const {
+    float progress = (float)ticks / total_ticks;
+    int pos = (int)(bar_width * progress);
+
+    std::chrono::steady_clock::time_point now =
+        std::chrono::steady_clock::now();
+    auto time_elapsed =
+        std::chrono::duration_cast<std::chrono::milliseconds>(now - start_time)
+            .count();
+
+    std::cout << "[";
+
+    for (int i = 0; i < bar_width; ++i) {
+      if (i < pos)
+        std::cout << complete_char;
+      else if (i == pos)
+        std::cout << ">";
+      else
+        std::cout << incomplete_char;
+    }
+    std::cout << "] " << int(progress * 100.0) << "% "
+              << float(time_elapsed) / 1000.0 << "s\r";
+    std::cout.flush();
+  }
+
+  void done() const {
+    display();
+    std::cout << std::endl;
+  }
+};
+}  // namespace progresscpp

--- a/src/algorithms/base_algorithm.hpp
+++ b/src/algorithms/base_algorithm.hpp
@@ -9,6 +9,7 @@
 #include "../hierarchies/base_hierarchy.hpp"
 #include "../mixings/base_mixing.hpp"
 #include "marginal_state.pb.h"
+#include "lib/progressbar/progressbar.hpp"
 
 //! Abstract template class for a Gibbs sampling iterative BNP algorithm.
 
@@ -102,14 +103,20 @@ class BaseAlgorithm {
     print_startup_message();
     unsigned int iter = 0;
     collector->start();
+
+    progresscpp::ProgressBar bar(maxiter, 60);
+    
     while (iter < maxiter) {
       step();
       if (iter >= burnin) {
         save_state(collector, iter);
       }
       iter++;
+     ++bar;
+     bar.display();
     }
     collector->finish();
+    bar.done();
     print_ending_message();
   }
 

--- a/src/algorithms/marginal_algorithm.cpp
+++ b/src/algorithms/marginal_algorithm.cpp
@@ -18,40 +18,48 @@ Eigen::MatrixXd MarginalAlgorithm::eval_lpdf(const Eigen::MatrixXd &grid,
 
   // Loop over non-burn-in algorithm iterations
   while(keep) {
-    Eigen::VectorXd curr_lpdf(grid.rows());
-    bayesmix::MarginalState state;
-    keep = coll->get_next_state(&state);
+    keep = update_state_from_collector(coll);
     if (! keep) {
       break;
     }
-
-    unsigned int n_data = state.cluster_allocs_size();
-    mixing->set_state_from_proto(state.mixing_state());
-    unsigned int n_clust = state.cluster_states_size();
-   
-    // Initialize local matrix of log-densities
-    Eigen::MatrixXd lpdf_local(grid.rows(), n_clust + 1);
-    std::shared_ptr<BaseHierarchy> temp_hier = unique_values[0]->clone();
-
-    Eigen::VectorXd weights(n_clust + 1);
-    for (size_t j = 0; j < n_clust; j++) {
-      // Extract and copy unique values in temp_hier
-      bayesmix::MarginalState::ClusterState curr_val =
-          state.cluster_states(j);
-      temp_hier->set_state_from_proto(curr_val);
-      // Compute cluster component (vector + scalar * unity vector)
-      lpdf_local.col(j) =
-          mixing->mass_existing_cluster(temp_hier, n_data, true, false) +
-          temp_hier->like_lpdf_grid(grid).array();
-    }
-    // Compute marginal component (vector + scalar * unity vector)
-    lpdf_local.col(n_clust) =
-        mixing->mass_new_cluster(n_clust, n_data, true, false) +
-        lpdf_marginal_component(temp_hier, grid).array();
-    for (size_t j = 0; j < grid.rows(); j++) {
-      curr_lpdf(j) = stan::math::log_sum_exp(lpdf_local.row(j));
-    }
-    lpdf.push_back(curr_lpdf);
+    lpdf.push_back(lpdf_from_state(grid));
   }
   return bayesmix::stack_vectors(lpdf);
+}
+
+Eigen::VectorXd MarginalAlgorithm::lpdf_from_state(
+    const Eigen::MatrixXd &grid) {
+  
+  Eigen::VectorXd out(grid.rows());
+  unsigned int n_data = curr_state.cluster_allocs_size();
+  unsigned int n_clust = curr_state.cluster_states_size();
+  mixing->set_state_from_proto(curr_state.mixing_state());
+
+  // Initialize local matrix of log-densities
+  Eigen::MatrixXd lpdf_local(grid.rows(), n_clust + 1);
+  std::shared_ptr<BaseHierarchy> temp_hier = unique_values[0]->clone();
+
+  Eigen::VectorXd weights(n_clust + 1);
+  for (size_t j = 0; j < n_clust; j++) {
+    // Extract and copy unique values in temp_hier
+    temp_hier->set_state_from_proto(curr_state.cluster_states(j));
+    // Compute cluster component (vector + scalar * unity vector)
+    lpdf_local.col(j) =
+        mixing->mass_existing_cluster(temp_hier, n_data, true, false) +
+        temp_hier->like_lpdf_grid(grid).array();
+  }
+  // Compute marginal component (vector + scalar * unity vector)
+  lpdf_local.col(n_clust) =
+      mixing->mass_new_cluster(n_clust, n_data, true, false) +
+      lpdf_marginal_component(temp_hier, grid).array();
+  
+  for (size_t j = 0; j < grid.rows(); j++) {
+    out(j) = stan::math::log_sum_exp(lpdf_local.row(j));
+  }
+  return out;
+}
+
+bool MarginalAlgorithm::update_state_from_collector(BaseCollector *coll) {
+  bool success = coll->get_next_state(&curr_state);
+  return success;
 }

--- a/src/algorithms/marginal_algorithm.cpp
+++ b/src/algorithms/marginal_algorithm.cpp
@@ -24,6 +24,7 @@ Eigen::MatrixXd MarginalAlgorithm::eval_lpdf(const Eigen::MatrixXd &grid,
     }
     lpdf.push_back(lpdf_from_state(grid));
   }
+  coll->reset();
   return bayesmix::stack_vectors(lpdf);
 }
 

--- a/src/algorithms/marginal_algorithm.hpp
+++ b/src/algorithms/marginal_algorithm.hpp
@@ -1,19 +1,26 @@
 #ifndef BAYESMIX_ALGORITHMS_MARGINAL_ALGORITHM_HPP_
 #define BAYESMIX_ALGORITHMS_MARGINAL_ALGORITHM_HPP_
 
+#include <google/protobuf/message.h>
+
 #include <Eigen/Dense>
 
-#include "marginal_state.pb.h"
 #include "../collectors/base_collector.hpp"
 #include "base_algorithm.hpp"
+#include "marginal_state.pb.h"
 
 class MarginalAlgorithm : public BaseAlgorithm {
+ protected:
+    bayesmix::MarginalState curr_state;
  public:
   ~MarginalAlgorithm() = default;
   MarginalAlgorithm() = default;
-  virtual Eigen::MatrixXd eval_lpdf(
-      const Eigen::MatrixXd &grid,
-      BaseCollector *const coll) override;
+  Eigen::MatrixXd eval_lpdf(const Eigen::MatrixXd &grid,
+                            BaseCollector *coll) override;
+
+  Eigen::VectorXd lpdf_from_state(const Eigen::MatrixXd &grid);
+
+  bool update_state_from_collector(BaseCollector *coll);
 };
 
 #endif  // BAYESMIX_ALGORITHMS_MARGINAL_ALGORITHM_HPP_

--- a/src/collectors/base_collector.hpp
+++ b/src/collectors/base_collector.hpp
@@ -52,6 +52,8 @@ class BaseCollector {
   //! Writes the given state to the collector
   virtual void collect(const google::protobuf::Message& state) = 0;
 
+  //! Resets the collector to the beginning of the chain
+  virtual void reset() = 0;
 
   unsigned int get_size() const { return size; }
 };

--- a/src/collectors/file_collector.cpp
+++ b/src/collectors/file_collector.cpp
@@ -61,3 +61,8 @@ void FileCollector::collect(const google::protobuf::Message &state) {
     std::cout << "Writing in FileCollector failed" << std::endl;
   }
 }
+
+void FileCollector::reset() {
+  curr_iter = 0;
+  close_reading();
+}

--- a/src/collectors/file_collector.hpp
+++ b/src/collectors/file_collector.hpp
@@ -60,6 +60,8 @@ class FileCollector : public BaseCollector {
 
   //! Writes the given state to the collector
   void collect(const google::protobuf::Message &state) override;
+
+  void reset() override;
 };
 
 #endif  // BAYESMIX_COLLECTORS_FILE_COLLECTOR_HPP_

--- a/src/collectors/memory_collector.cpp
+++ b/src/collectors/memory_collector.cpp
@@ -19,3 +19,5 @@ void MemoryCollector::get_state(unsigned int i,
                                 google::protobuf::Message* out) {
   out->ParseFromString(chain[i]);
 }
+
+void MemoryCollector::reset() { curr_iter = 0; }

--- a/src/collectors/memory_collector.hpp
+++ b/src/collectors/memory_collector.hpp
@@ -40,9 +40,6 @@ class MemoryCollector : public BaseCollector {
   //! Returns i-th state in the collector
   void get_state(unsigned int i, google::protobuf::Message* out);
 
-  // //! Returns the whole chain in form of a deque of States
-  // std::deque<MsgType> get_chain() override { return chain; }
-
   template <typename MsgType>
   void write_to_file(std::string outfile) {
     // THIS is probabily a HACK: we de-serialize from the chain

--- a/src/collectors/memory_collector.hpp
+++ b/src/collectors/memory_collector.hpp
@@ -36,6 +36,8 @@ class MemoryCollector : public BaseCollector {
   //! Writes the given state to the collector
   void collect(const google::protobuf::Message& state) override;
 
+  void reset() override;
+
   // GETTERS AND SETTERS
   //! Returns i-th state in the collector
   void get_state(unsigned int i, google::protobuf::Message* out);

--- a/test/collectors.cpp
+++ b/test/collectors.cpp
@@ -3,7 +3,7 @@
 #include <Eigen/Dense>
 #include <vector>
 
-#include "../proto/cpp/matrix.pb.h"
+#include "matrix.pb.h"
 #include "../src/collectors/file_collector.hpp"
 #include "../src/collectors/memory_collector.hpp"
 #include "../src/utils/proto_utils.hpp"


### PR DESCRIPTION
This is a quick&dirty PR with 3 little changes:
1. I added a 'reset' method to the collectors that resets a collector to the first iteration
2. I split the 'eval_lpdf' method of the MarginalAlgorithm into 3 different methods (this could be handy if we want to evaluate only the mean of the pdf without storing all the matrix of num_iterations x grid_size)
3. added a progress-bar (found online) to display the progress of the MCMC algorithm, which is also shown in python