### PR TITLE
Collectors

### DIFF
--- a/src/algorithms/base_algorithm.hpp
+++ b/src/algorithms/base_algorithm.hpp
@@ -102,7 +102,7 @@ class BaseAlgorithm {
     initialize();
     print_startup_message();
     unsigned int iter = 0;
-    collector->start();
+    collector->start_collecting();
 
     progresscpp::ProgressBar bar(maxiter, 60);
     
@@ -115,7 +115,7 @@ class BaseAlgorithm {
      ++bar;
      bar.display();
     }
-    collector->finish();
+    collector->finish_collecting();
     bar.done();
     print_ending_message();
   }

--- a/src/collectors/base_collector.hpp
+++ b/src/collectors/base_collector.hpp
@@ -40,9 +40,9 @@ class BaseCollector {
   BaseCollector() = default;
 
   //! Initializes collector
-  virtual void start() = 0;
+  virtual void start_collecting() = 0;
   //! Closes collector
-  virtual void finish() = 0;
+  virtual void finish_collecting() = 0;
 
   //! Reads the next state and advances the cursor by 1
   bool get_next_state(google::protobuf::Message *out) {

--- a/src/collectors/base_collector.hpp
+++ b/src/collectors/base_collector.hpp
@@ -19,7 +19,7 @@
 //! collector for short. A collector is meant to store the state of a Markov
 //! chain at all iterations, composed of the allocations and the unique values
 //! vectors. These values are stored in classes built via the Google Protocol
-//! Buffers library, also known as Protobuf. In particular, t the end of each
+//! Buffers library, also known as Protobuf. In particular, at the end of each
 //! iteration of a BNP algorithm of this library, its state is saved to the
 //! collector. This means that the collector will contain the states of the
 //! whole Markov chain by the end of the running of the algorithm.

--- a/src/collectors/file_collector.cpp
+++ b/src/collectors/file_collector.cpp
@@ -38,13 +38,13 @@ bool FileCollector::next_state(google::protobuf::Message *out) {
   return keep;
 }
 
-void FileCollector::start() {
+void FileCollector::start_collecting() {
   int outfd = open(filename.c_str(), O_RDWR | O_CREAT | O_TRUNC, 0777);
   fout = new google::protobuf::io::FileOutputStream(outfd);
   is_open_write = true;
 }
 
-void FileCollector::finish() {
+void FileCollector::finish_collecting() {
   if (is_open_write) {
     fout->Close();
     close(outfd);

--- a/src/collectors/file_collector.hpp
+++ b/src/collectors/file_collector.hpp
@@ -54,9 +54,9 @@ class FileCollector : public BaseCollector {
   }
   FileCollector(const std::string &filename_) : filename(filename_) {}
   //! Initializes collector
-  void start() override;
+  void start_collecting() override;
   //! Closes collector
-  void finish() override;
+  void finish_collecting() override;
 
   //! Writes the given state to the collector
   void collect(const google::protobuf::Message &state) override;

--- a/src/collectors/file_collector.hpp
+++ b/src/collectors/file_collector.hpp
@@ -31,7 +31,7 @@ class FileCollector : public BaseCollector {
   //! Flag that indicates if the collector is open in read-mode
   bool is_open_read = false;
   //! Flag that indicates if the collector is open in write-mode
-  bool is_open_write;
+  bool is_open_write = false;
 
   //! Opens collector in reading mode
   void open_for_reading();

--- a/src/collectors/memory_collector.cpp
+++ b/src/collectors/memory_collector.cpp
@@ -6,6 +6,7 @@ bool MemoryCollector::next_state(google::protobuf::Message* out) {
     return false;
   }
   out->ParseFromString(chain[curr_iter]);
+  return true;
 }
 
 void MemoryCollector::collect(const google::protobuf::Message& state) {

--- a/src/collectors/memory_collector.hpp
+++ b/src/collectors/memory_collector.hpp
@@ -29,9 +29,9 @@ class MemoryCollector : public BaseCollector {
   MemoryCollector() = default;
 
   //! Initializes collector (here, it does nothing)
-  void start() override { return; }
+  void start_collecting() override { return; }
   //! Closes collector (here, it does nothing)
-  void finish() override { return; }
+  void finish_collecting() override { return; }
 
   //! Writes the given state to the collector
   void collect(const google::protobuf::Message& state) override;

--- a/test/collectors.cpp
+++ b/test/collectors.cpp
@@ -10,7 +10,7 @@
 
 TEST(collectors, memory) {
   MemoryCollector coll;
-  coll.start();
+  coll.start_collecting();
 
   std::vector<Eigen::VectorXd> chain(5);
   for (int i = 0; i < 5; i++) {
@@ -19,7 +19,7 @@ TEST(collectors, memory) {
     to_proto(chain[i], &curr);
     coll.collect(curr);
   }
-  coll.finish();
+  coll.finish_collecting();
 
   int iter = 0;
   bool keep = true;
@@ -39,7 +39,7 @@ TEST(collectors, memory) {
 
 TEST(collectors, file_writing) {
   FileCollector coll("test.recordio");
-  coll.start();
+  coll.start_collecting();
   std::vector<Eigen::VectorXd> chain(5);
   for (int i = 0; i < 5; i++) {
     chain[i] = Eigen::VectorXd::Ones(3) * i;
@@ -47,12 +47,12 @@ TEST(collectors, file_writing) {
     to_proto(chain[i], &curr);
     coll.collect(curr);
   }
-  coll.finish();
+  coll.finish_collecting();
 }
 
 TEST(collectors, file_reading) {
   FileCollector coll("test.recordio");
-  coll.start();
+  coll.start_collecting();
 
   std::vector<Eigen::VectorXd> chain(5);
   for (int i = 0; i < 5; i++) {
@@ -61,7 +61,7 @@ TEST(collectors, file_reading) {
     to_proto(chain[i], &curr);
     coll.collect(curr);
   }
-  coll.finish();
+  coll.finish_collecting();
 
   FileCollector coll2("test.recordio");
   int iter = 0;

--- a/test/collectors.cpp
+++ b/test/collectors.cpp
@@ -10,6 +10,7 @@
 
 TEST(collectors, memory) {
   MemoryCollector coll;
+  coll.start();
 
   std::vector<Eigen::VectorXd> chain(5);
   for (int i = 0; i < 5; i++) {
@@ -18,6 +19,7 @@ TEST(collectors, memory) {
     to_proto(chain[i], &curr);
     coll.collect(curr);
   }
+  coll.finish();
 
   int iter = 0;
   bool keep = true;

--- a/test/collectors.cpp
+++ b/test/collectors.cpp
@@ -62,20 +62,18 @@ TEST(collectors, file_reading) {
   coll.finish();
 
   FileCollector coll2("test.recordio");
-  coll2.start();
   int iter = 0;
   bool keep = true;
   while (keep) {
     bayesmix::Vector curr;
     keep = coll2.get_next_state(&curr);
     if (!keep) {
+      iter--;
       break;
     }
     ASSERT_EQ(curr.size(), 3);
     ASSERT_EQ(curr.data(0), iter);
     iter++;
   }
-
   ASSERT_EQ(chain[iter](0), chain[4][0]);
-  coll2.finish();
 }


### PR DESCRIPTION
This PR closes #29. The collectors themselves were completely fine (except for one flag that needed an appropriate default value) -- it was the test that was ill-coded. I shall briefly remind how the file collector is to be used. First of all, start() and finish() are used _for writing only_, and in particular start() empties the collector file -- that's why coll2 was empty. Reading does _not_ need any initializing or closing functions, since the correct flag is automatically set upon starting reading and the destructor handles the closure of the file. Secondly, the for loop needed an `iter--` since the iteration number at `break` was one past the last element.

If you think the current structure needs changes, or if you think we should name these functions better (they are fine for me), please let me know.