### PR TITLE
Everyone gets a progressbar! + misc. fixes

### DIFF
--- a/run.cpp
+++ b/run.cpp
@@ -108,7 +108,9 @@ int main(int argc, char *argv[]) {
   std::cout << "Successfully wrote cluster sizes to " << nclufile << std::endl;
 
   // Compute cluster estimate
+  std::cout << "Computing cluster estimate..." << std::endl;
   Eigen::VectorXd clust_est = bayesmix::cluster_estimate(clusterings);
+  std::cout << "Done" << std::endl;
   bayesmix::write_matrix_to_file(clust_est, clusfile);
   std::cout << "Successfully wrote clustering to " << clusfile << std::endl;
 

--- a/run.cpp
+++ b/run.cpp
@@ -108,9 +108,7 @@ int main(int argc, char *argv[]) {
   std::cout << "Successfully wrote cluster sizes to " << nclufile << std::endl;
 
   // Compute cluster estimate
-  std::cout << "Computing cluster estimate..." << std::endl;
   Eigen::VectorXd clust_est = bayesmix::cluster_estimate(clusterings);
-  std::cout << "Done" << std::endl;
   bayesmix::write_matrix_to_file(clust_est, clusfile);
   std::cout << "Successfully wrote clustering to " << clusfile << std::endl;
 

--- a/run.cpp
+++ b/run.cpp
@@ -87,11 +87,14 @@ int main(int argc, char *argv[]) {
 
   // Collect mixing and cluster states
   Eigen::VectorXd masses(coll->get_size());
-  // Eigen::MatrixXd clusterings(chain.size(), data.rows());
+  Eigen::MatrixXd clusterings(coll->get_size(), data.rows());
   Eigen::VectorXd num_clust(coll->get_size());
   for (int i = 0; i < coll->get_size(); i++) {
     bayesmix::MarginalState state;
     coll->get_next_state(&state);
+    for (int j = 0; j < data.rows(); j++){
+      clusterings(i, j) = state.cluster_allocs(j);
+    }
     num_clust(i) = state.cluster_states_size();
     bayesmix::MixingState mixstate = state.mixing_state();
     if (mixstate.has_dp_state()) {
@@ -104,12 +107,12 @@ int main(int argc, char *argv[]) {
   bayesmix::write_matrix_to_file(num_clust, nclufile);
   std::cout << "Successfully wrote cluster sizes to " << nclufile << std::endl;
 
-  // // Compute cluster estimate
-  // std::cout << "Computing cluster estimate..." << std::endl;
-  // Eigen::VectorXd clust_est = bayesmix::cluster_estimate(clusterings);
-  // std::cout << "Done" << std::endl;
-  // bayesmix::write_matrix_to_file(clust_est, clusfile);
-  // std::cout << "Successfully wrote clustering to " << clusfile << std::endl;
+  // Compute cluster estimate
+  std::cout << "Computing cluster estimate..." << std::endl;
+  Eigen::VectorXd clust_est = bayesmix::cluster_estimate(clusterings);
+  std::cout << "Done" << std::endl;
+  bayesmix::write_matrix_to_file(clust_est, clusfile);
+  std::cout << "Successfully wrote clustering to " << clusfile << std::endl;
 
   std::cout << "End of run.cpp" << std::endl;
   delete coll;

--- a/src/algorithms/base_algorithm.cpp
+++ b/src/algorithms/base_algorithm.cpp
@@ -7,7 +7,7 @@
 #include "mixing_state.pb.h"
 
 void BaseAlgorithm::initialize() {
-  std::cout << "Initializing... ";
+  std::cout << "Initializing... " << std::flush;
 
   // Perform checks
   assert(data.rows() != 0 && "Error: empty data matrix");

--- a/src/algorithms/base_algorithm.cpp
+++ b/src/algorithms/base_algorithm.cpp
@@ -7,7 +7,7 @@
 #include "mixing_state.pb.h"
 
 void BaseAlgorithm::initialize() {
-  std::cout << "Initializing..." << std::endl;
+  std::cout << "Initializing... ";
 
   // Perform checks
   assert(data.rows() != 0 && "Error: empty data matrix");
@@ -46,6 +46,8 @@ void BaseAlgorithm::initialize() {
     allocations.push_back(clust);
     unique_values[clust]->add_datum(i, data.row(i));
   }
+
+  std::cout << "Done" << std::endl;
 }
 
 void BaseAlgorithm::update_hierarchy_hypers() {

--- a/src/algorithms/marginal_algorithm.cpp
+++ b/src/algorithms/marginal_algorithm.cpp
@@ -6,6 +6,7 @@
 #include "marginal_state.pb.h"
 #include "../collectors/base_collector.hpp"
 #include "../utils/eigen_utils.hpp"
+#include "../../lib/progressbar/progressbar.hpp"
 
 //! \param grid Grid of points in matrix form to evaluate the density on
 //! \param coll Collector containing the algorithm chain
@@ -15,6 +16,7 @@ Eigen::MatrixXd MarginalAlgorithm::eval_lpdf(const Eigen::MatrixXd &grid,
  
   std::deque<Eigen::VectorXd> lpdf;
   bool keep = true;
+  progresscpp::ProgressBar bar(coll->get_size(), 60);
 
   // Loop over non-burn-in algorithm iterations
   while(keep) {
@@ -23,8 +25,11 @@ Eigen::MatrixXd MarginalAlgorithm::eval_lpdf(const Eigen::MatrixXd &grid,
       break;
     }
     lpdf.push_back(lpdf_from_state(grid));
+    ++bar;
+    bar.display();
   }
   coll->reset();
+  bar.done();
   return bayesmix::stack_vectors(lpdf);
 }
 

--- a/src/collectors/base_collector.hpp
+++ b/src/collectors/base_collector.hpp
@@ -29,7 +29,7 @@ class BaseCollector {
   //! Current size of the chain
   unsigned int size = 0;
   //! Read cursor that indicates the current iteration
-  unsigned int curr_iter = -1;
+  unsigned int curr_iter = 0;
 
   //! Reads the next state, based on the curr_iter curson
   virtual bool next_state(google::protobuf::Message *out) = 0;

--- a/src/collectors/file_collector.cpp
+++ b/src/collectors/file_collector.cpp
@@ -25,9 +25,6 @@ bool FileCollector::next_state(google::protobuf::Message *out) {
     open_for_reading();
   }
   curr_iter++;
-//  std::cout << "FileCollector::next_state, curr_iter: " << curr_iter
-//            << std::endl;
-
   bool keep = google::protobuf::util::ParseDelimitedFromZeroCopyStream(
       out, fin, nullptr);
   if (!keep) {

--- a/src/collectors/file_collector.cpp
+++ b/src/collectors/file_collector.cpp
@@ -25,14 +25,13 @@ bool FileCollector::next_state(google::protobuf::Message *out) {
     open_for_reading();
   }
   curr_iter++;
-  std::cout << "FileCollector::next_state, curr_iter: " << curr_iter
-            << std::endl;
+//  std::cout << "FileCollector::next_state, curr_iter: " << curr_iter
+//            << std::endl;
 
   bool keep = google::protobuf::util::ParseDelimitedFromZeroCopyStream(
       out, fin, nullptr);
-  std::cout << "keep: " << keep << std::endl;
   if (!keep) {
-    curr_iter = -1;
+    curr_iter = 0;
     close_reading();
   }
   return keep;

--- a/src/collectors/memory_collector.cpp
+++ b/src/collectors/memory_collector.cpp
@@ -1,11 +1,11 @@
 #include "memory_collector.hpp"
 
 bool MemoryCollector::next_state(google::protobuf::Message* out) {
-  curr_iter++;
-  if (curr_iter == size - 1) {
+  if (curr_iter == size) {
     return false;
   }
   out->ParseFromString(chain[curr_iter]);
+  curr_iter++;
   return true;
 }
 

--- a/src/utils/cluster_utils.cpp
+++ b/src/utils/cluster_utils.cpp
@@ -15,39 +15,33 @@ Eigen::VectorXd bayesmix::cluster_estimate(
   unsigned int n_data = alloc_chain.cols();
   Eigen::MatrixXd mean_diss = Eigen::MatrixXd::Zero(n_data, n_data);
   std::vector<Eigen::SparseMatrix<double> > all_diss;
-  progresscpp::ProgressBar bar(2*n_iter, 60);
+  progresscpp::ProgressBar bar(n_iter, 60);
+  std::cout << "Computing mean dissimilarity... " << std::flush;
 
-  // Loop over iterations
-  for (size_t i = 0; i < n_iter; i++) {
-    // Find and all nonzero entries of the dissimilarity matrix
-    std::vector<Eigen::Triplet<double> > triplets_list;
-    triplets_list.reserve(n_data * n_data / 4);
-    for (size_t j = 0; j < n_data; j++) {
-      for (size_t k = 0; k < j; k++) {
-        if (alloc_chain(i, j) == alloc_chain(i, k)) {
-          triplets_list.push_back(Eigen::Triplet<double>(j, k, 1.0));
+  // Loop over pairs (i,j) of data points
+  for (int i = 0; i < n_data; i++) {
+    for (int j = 0; j < i; j++) {
+      // Compute mean dissimilarity for (i,j) by looping over iterations
+      for (int k = 0; k < n_iter; k++) {
+        if (alloc_chain(k, i) == alloc_chain(k, j)) {
+          mean_diss(i, j) += 1.0;
         }
+      mean_diss(i, j) = mean_diss(i, j) / n_iter;
       }
     }
-    // Build dissimilarity matrix and update total dissimilarity
-    Eigen::SparseMatrix<double> dissim(n_data, n_data);
-    dissim.setZero();
-    dissim.setFromTriplets(triplets_list.begin(), triplets_list.end());
-    all_diss.push_back(dissim);
-    mean_diss += dissim;
-
-    // Progress bar
-    ++bar;
-    bar.display();
   }
-
-  // Average over iterations
-  mean_diss = mean_diss / n_iter;
+  std::cout << "Done" << std::endl;
+  std::cout << "Computing cluster estimate..." << std::endl;
 
   // Compute Frobenius norm error of all iterations
   Eigen::VectorXd errors(n_iter);
-  for (size_t i = 0; i < n_iter; i++) {
-    errors(i) = (mean_diss - all_diss[i]).norm();
+  for (int k = 0; k < n_iter; k++) {
+    for (int i = 0; i < n_data; i++) {
+      for (int j = 0; j < i; j++) {
+        int x = (alloc_chain(k, i) == alloc_chain(k, j));
+        errors(k) += (x - mean_diss(i, j)) * (x - mean_diss(i, j));
+      }
+    }
     // Progress bar
     ++bar;
     bar.display();
@@ -57,5 +51,6 @@ Eigen::VectorXd bayesmix::cluster_estimate(
   // Find iteration with the least error
   std::ptrdiff_t ibest;
   unsigned int min_err = errors.minCoeff(&ibest);
+  std::cout << "Done" << std::endl;
   return alloc_chain.row(ibest).transpose();
 }

--- a/src/utils/cluster_utils.cpp
+++ b/src/utils/cluster_utils.cpp
@@ -4,6 +4,7 @@
 #include <Eigen/SparseCore>
 
 #include "proto_utils.hpp"
+#include "../../lib/progressbar/progressbar.hpp"
 
 //! \param coll Collector containing the algorithm chain
 //! \return     Index of the iteration containing the best estimate
@@ -14,13 +15,14 @@ Eigen::VectorXd bayesmix::cluster_estimate(
   unsigned int n_data = alloc_chain.cols();
   Eigen::MatrixXd mean_diss = Eigen::MatrixXd::Zero(n_data, n_data);
   std::vector<Eigen::SparseMatrix<double> > all_diss;
+  progresscpp::ProgressBar bar(2*n_iter, 60);
 
   // Loop over iterations
   for (size_t i = 0; i < n_iter; i++) {
     // Find and all nonzero entries of the dissimilarity matrix
     std::vector<Eigen::Triplet<double> > triplets_list;
     triplets_list.reserve(n_data * n_data / 4);
-    for (size_t j = 0; j < n_data; i++) {
+    for (size_t j = 0; j < n_data; j++) {
       for (size_t k = 0; k < j; k++) {
         if (alloc_chain(i, j) == alloc_chain(i, k)) {
           triplets_list.push_back(Eigen::Triplet<double>(j, k, 1.0));
@@ -33,7 +35,12 @@ Eigen::VectorXd bayesmix::cluster_estimate(
     dissim.setFromTriplets(triplets_list.begin(), triplets_list.end());
     all_diss.push_back(dissim);
     mean_diss += dissim;
+
+    // Progress bar
+    ++bar;
+    bar.display();
   }
+
   // Average over iterations
   mean_diss = mean_diss / n_iter;
 
@@ -41,7 +48,11 @@ Eigen::VectorXd bayesmix::cluster_estimate(
   Eigen::VectorXd errors(n_iter);
   for (size_t i = 0; i < n_iter; i++) {
     errors(i) = (mean_diss - all_diss[i]).norm();
+    // Progress bar
+    ++bar;
+    bar.display();
   }
+  bar.done();
 
   // Find iteration with the least error
   std::ptrdiff_t ibest;

--- a/src/utils/cluster_utils.cpp
+++ b/src/utils/cluster_utils.cpp
@@ -16,22 +16,16 @@ Eigen::VectorXd bayesmix::cluster_estimate(
   Eigen::MatrixXd mean_diss = Eigen::MatrixXd::Zero(n_data, n_data);
   std::vector<Eigen::SparseMatrix<double> > all_diss;
   progresscpp::ProgressBar bar(n_iter, 60);
-  std::cout << "Computing mean dissimilarity... " << std::flush;
+  std::cout << "(Computing mean dissimilarity... " << std::flush;
 
   // Loop over pairs (i,j) of data points
   for (int i = 0; i < n_data; i++) {
     for (int j = 0; j < i; j++) {
-      // Compute mean dissimilarity for (i,j) by looping over iterations
-      for (int k = 0; k < n_iter; k++) {
-        if (alloc_chain(k, i) == alloc_chain(k, j)) {
-          mean_diss(i, j) += 1.0;
-        }
-      mean_diss(i, j) = mean_diss(i, j) / n_iter;
-      }
+      Eigen::ArrayXd diff = alloc_chain.col(i) - alloc_chain.col(j);
+      mean_diss(i, j) = 1.0 * (diff == 0).count() / n_iter;
     }
   }
-  std::cout << "Done" << std::endl;
-  std::cout << "Computing cluster estimate..." << std::endl;
+  std::cout << "Done)" << std::endl;
 
   // Compute Frobenius norm error of all iterations
   Eigen::VectorXd errors(n_iter);
@@ -51,6 +45,5 @@ Eigen::VectorXd bayesmix::cluster_estimate(
   // Find iteration with the least error
   std::ptrdiff_t ibest;
   unsigned int min_err = errors.minCoeff(&ibest);
-  std::cout << "Done" << std::endl;
   return alloc_chain.row(ibest).transpose();
 }

--- a/src/utils/cluster_utils.hpp
+++ b/src/utils/cluster_utils.hpp
@@ -4,6 +4,8 @@
 #include <Eigen/Dense>
 
 namespace bayesmix {
+//! Computes the posterior similarity matrix the data
+Eigen::MatrixXd posterior_similarity(const Eigen::MatrixXd &alloc_chain);
 //! Estimates the clustering structure of the data via LS minimization
 Eigen::VectorXd cluster_estimate(const Eigen::MatrixXd &alloc_chain);
 }  // namespace bayesmix

--- a/test/collectors.cpp
+++ b/test/collectors.cpp
@@ -27,6 +27,7 @@ TEST(collectors, memory) {
     bayesmix::Vector curr;
     keep = coll.get_next_state(&curr);
     if (!keep) {
+      iter--;
       break;
     }
     ASSERT_EQ(curr.size(), 3);


### PR DESCRIPTION
The progress bar is so unbelievably beautiful, that I just _had_ to add one to density estimation and clustering.

Jokes aside, the different behaviors exhibited by file and memory collectors in yesterday's tests, namely the need of `iter--` for one but not for the other, kinda left me wondering. And upon further inspection, I came across several bugs, including some stupid ones like setting the initial value of the cursor, an unsigned int, to -1 (whoops!). Now both collectors and their tests run fine.

After that, I thought I might as well add the progress bars, including to the clustering tool (so that I could actually measure how slow it was), and I _also_ came across a bug there. This time I was doing an `i++` instead of a `j++`, and thus we had an infinite loop. That's why the clustering appeared to take so long... 😳
Now that it works as intended, you can see that it's actually pretty fast, so I added it back to run.cpp.

I promise I'm going back to the algorithms after this one.