### PR TITLE
Blocked Gibbs algorithm

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,6 +75,11 @@ target_include_directories(run PUBLIC ${INCLUDE_PATHS})
 target_link_libraries(run PUBLIC ${LINK_LIBRARIES})
 target_compile_options(run PUBLIC ${COMPILE_OPTIONS})
 
+add_executable(dependent_run $<TARGET_OBJECTS:bayesmix> dependent_run.cc)
+target_include_directories(dependent_run PUBLIC ${INCLUDE_PATHS})
+target_link_libraries(dependent_run PUBLIC ${LINK_LIBRARIES})
+target_compile_options(dependent_run PUBLIC ${COMPILE_OPTIONS})
+
 if (NOT DISABLE_TESTS)
   # Build test executable
   add_subdirectory(test)

--- a/algo_settings.asciipb
+++ b/algo_settings.asciipb
@@ -1,6 +1,6 @@
 ##### GENERIC SETTINGS FOR ALL ALGORITHMS #####
 # Algorithm ID string, e.g. "Neal2"
-algo_id: "Neal2"
+algo_id: "BlockedGibbs"
 
 # RNG initial seed: any nonnegative integer
 rng_seed: 20201124

--- a/algo_settings.asciipb
+++ b/algo_settings.asciipb
@@ -13,8 +13,10 @@ burnin: 100
 
 # Number of clusters in which data will be first initialized
 # (NOTE: If you wish to initialize one datum per cluster, please write 0.)
-# (NOTE: In the BlockedGibbs algorithm, this argument will be overwritten by
-#  the num_components parameter from its mixing prior.)
+# (NOTE: This value is ONLY used for initialization, and it may be overwritten
+#  by certain mixing objects, such as LogSBMixing. Please check a mixing's
+#  initialize() function to know for sure whether or not it will override this
+#  value.)
 init_num_clusters: 3
 
 

--- a/algo_settings.asciipb
+++ b/algo_settings.asciipb
@@ -12,8 +12,9 @@ iterations: 1000
 burnin: 100
 
 # Number of clusters in which data will be first initialized
-# (NOTE: If you want to initialize one datum per cluster, please write 0.)
-# (NOTE: This argument will be ignored by the BlockedGibbs algorithm.)
+# (NOTE: If you wish to initialize one datum per cluster, please write 0.)
+# (NOTE: In the BlockedGibbs algorithm, this argument will be overwritten by
+#  the num_components parameter from its mixing prior.)
 init_num_clusters: 3
 
 

--- a/bash/run_test.sh
+++ b/bash/run_test.sh
@@ -8,7 +8,6 @@
 #   datafile \
 #   gridfile \
 #   densfile \
-#   massfile \
 #   nclufile \
 #   clusfile \
 #   [hier_cov_file] \
@@ -25,7 +24,6 @@ if [ "$1" == 'uni' ]; then
     resources/csv/in/data_uni.csv \
     resources/csv/in/grid_uni.csv \
     resources/csv/out/uni_dens.csv \
-    resources/csv/out/uni_mass.csv \
     resources/csv/out/uni_nclu.csv \
     resources/csv/out/uni_clus.csv
 elif [ "$1" == 'multi' ]; then
@@ -37,7 +35,6 @@ elif [ "$1" == 'multi' ]; then
     resources/csv/in/data_multi.csv \
     resources/csv/in/grid_multi.csv \
     resources/csv/out/multi_dens.csv \
-    resources/csv/out/multi_mass.csv \
     resources/csv/out/multi_nclu.csv \
     resources/csv/out/multi_clus.csv
 elif [ "$1" == 'lru' ]; then
@@ -49,7 +46,6 @@ elif [ "$1" == 'lru' ]; then
     resources/csv/in/data_lru.csv \
     resources/csv/in/grid_lru.csv \
     resources/csv/out/lru_dens.csv \
-    resources/csv/out/lru_mass.csv \
     resources/csv/out/lru_nclu.csv \
     resources/csv/out/lru_clus.csv \
     resources/csv/in/lru_hier_cov.csv \
@@ -63,7 +59,6 @@ elif [ "$1" == 'sb' ]; then
     resources/csv/in/logsb_data.csv \
     resources/csv/in/logsb_grid_data.csv \
     resources/csv/out/logsb_dens.csv \
-    resources/csv/out/logsb_mass.csv \
     resources/csv/out/logsb_nclu.csv \
     resources/csv/out/logsb_clus.csv \
     "" \

--- a/bash/run_test.sh
+++ b/bash/run_test.sh
@@ -54,6 +54,22 @@ elif [ "$1" == 'lru' ]; then
     resources/csv/out/lru_clus.csv \
     resources/csv/in/lru_hier_cov.csv \
     resources/csv/in/lru_hier_cov_grid.csv
+elif [ "$1" == 'sb' ]; then
+  build/run \
+    algo_settings.asciipb \
+    NNIG  resources/asciipb/nnig_ngg_prior.asciipb \
+    LogSB resources/asciipb/lsb_normal_prior.asciipb \
+    "" \
+    resources/csv/in/logsb_data.csv \
+    resources/csv/in/logsb_grid_data.csv \
+    resources/csv/out/logsb_dens.csv \
+    resources/csv/out/logsb_mass.csv \
+    resources/csv/out/logsb_nclu.csv \
+    resources/csv/out/logsb_clus.csv \
+    "" \
+    "" \
+    resources/csv/in/logsb_cov_mix.csv \
+    resources/csv/in/logsb_grid_cov_mix.csv
 else
-  echo 'Syntax: bash/run_test.sh followed by one of: uni, multi, lru'
+  echo 'Syntax: bash/run_test.sh followed by one of: uni, multi, lru, sb'
 fi

--- a/bash/run_test.sh
+++ b/bash/run_test.sh
@@ -47,13 +47,13 @@ elif [ "$1" == 'lru' ]; then
     DP        resources/asciipb/dp_gamma_prior.asciipb \
     "" \
     resources/csv/in/data_lru.csv \
-    resources/csv/in/covs_grid_lru.csv \
+    resources/csv/in/grid_lru.csv \
     resources/csv/out/lru_dens.csv \
     resources/csv/out/lru_mass.csv \
     resources/csv/out/lru_nclu.csv \
     resources/csv/out/lru_clus.csv \
-    resources/csv/in/covs_lru.csv \
-    resources/csv/in/covs_grid_lru.csv
+    resources/csv/in/lru_hier_cov.csv \
+    resources/csv/in/lru_hier_cov_grid.csv
 else
   echo 'Syntax: bash/run_test.sh followed by one of: uni, multi, lru'
 fi

--- a/dependent_run.cc
+++ b/dependent_run.cc
@@ -1,0 +1,109 @@
+#include <math.h>
+
+#include <fstream>
+#include <iostream>
+
+#include "src/includes.h"
+#include "src/utils/eigen_utils.h"
+
+int main(int argc, char *argv[]) {
+  std::cout << "Running dependent_run.cc" << std::endl;
+
+  // Get console parameters
+  std::string algo_params_file = argv[1];
+  std::string hier_type = argv[2];
+  std::string hier_args = argv[3];
+  std::string mix_type = argv[4];
+  std::string mix_args = argv[5];
+  std::string collname = argv[6];
+  std::string datafile = argv[7];
+  std::string gridfile = argv[8];
+  std::string densfile = argv[9];
+  std::string nclufile = argv[10];
+  std::string clusfile = argv[11];
+  std::string hier_cov_file;
+  std::string hier_grid_cov_file;
+  std::string mix_cov_file;
+  std::string mix_grid_cov_file;
+  if (argc >= 14) {
+    hier_cov_file = argv[12];
+    hier_grid_cov_file = argv[13];
+  }
+  if (argc >= 16) {
+    mix_cov_file = argv[14];
+    mix_grid_cov_file = argv[15];
+  }
+
+  // Read algorithm settings proto
+  bayesmix::AlgorithmParams algo_proto;
+  bayesmix::read_proto_from_file(algo_params_file, &algo_proto);
+
+  // Create factories and objects
+  auto &factory_algo = AlgorithmFactory::Instance();
+  auto &factory_hier = HierarchyFactory::Instance();
+  auto &factory_mixing = MixingFactory::Instance();
+  auto algo = factory_algo.create_object(algo_proto.algo_id());
+  auto hier = factory_hier.create_object(hier_type);
+  auto mixing = factory_mixing.create_object(mix_type);
+  BaseCollector *coll;
+  if (collname == "") {
+    coll = new MemoryCollector();
+  } else {
+    coll = new FileCollector(collname);
+  }
+
+  bayesmix::read_proto_from_file(mix_args, mixing->get_mutable_prior());
+  bayesmix::read_proto_from_file(hier_args, hier->get_mutable_prior());
+
+  // Read data matrices
+  Eigen::MatrixXd data = bayesmix::read_eigen_matrix(datafile);
+  Eigen::MatrixXd grid = bayesmix::read_eigen_matrix(gridfile);
+  Eigen::MatrixXd hier_cov_grid = Eigen::RowVectorXd(0);
+  Eigen::MatrixXd mix_cov_grid = Eigen::RowVectorXd(0);
+  if (hier->is_dependent()) {
+    hier_cov_grid = bayesmix::read_eigen_matrix(hier_grid_cov_file);
+  }
+  if (mixing->is_dependent()) {
+    mix_cov_grid = bayesmix::read_eigen_matrix(mix_grid_cov_file);
+  }
+
+  // Set algorithm parameters
+  algo->read_params_from_proto(algo_proto);
+
+  // Allocate objects in algorithm
+  algo->set_mixing(mixing);
+  algo->set_data(data);
+  algo->set_hierarchy(hier);
+
+  // Read and set covariates
+  if (hier->is_dependent()) {
+    Eigen::MatrixXd hier_cov = bayesmix::read_eigen_matrix(hier_cov_file);
+    algo->set_hier_covariates(hier_cov);
+  }
+  if (mixing->is_dependent()) {
+    Eigen::MatrixXd mix_cov = bayesmix::read_eigen_matrix(mix_cov_file);
+    algo->set_mix_covariates(mix_cov);
+  }
+
+  // Run algorithm and density evaluations
+  algo->run(coll);
+  std::cout << "Computing log-densities..." << std::endl;
+  Eigen::MatrixXd dens(mix_cov_grid.rows(), grid.rows());
+  for (int i = 0; i < mix_cov_grid.rows(); i++) {
+    Eigen::VectorXd dens_mean_i(grid.rows());
+    Eigen::MatrixXd tmp =
+        algo->eval_lpdf(coll, grid, hier_cov_grid,
+                        mix_cov_grid.row(i));
+    for (int j = 0; j < coll->get_size(); j++) {
+      dens_mean_i += tmp.row(j);
+    }
+    dens.row(i) = dens_mean_i / coll->get_size();
+  }
+  std::cout << "Done" << std::endl;
+  bayesmix::write_matrix_to_file(dens, densfile);
+  std::cout << "Successfully wrote densities to " << densfile << std::endl;
+
+  std::cout << "End of dependent_run.cc" << std::endl;
+  delete coll;
+  return 0;
+}

--- a/proto/algorithm_state.proto
+++ b/proto/algorithm_state.proto
@@ -5,7 +5,7 @@ import "ls_state.proto";
 
 package bayesmix;
 
-message MarginalState {
+message AlgorithmState {
   message ClusterState {
     oneof val {
       UniLSState uni_ls_state = 1;

--- a/python/generate_asciipb.py
+++ b/python/generate_asciipb.py
@@ -28,7 +28,7 @@ if __name__ == "__main__":
     PrintMessage(py_prior, f)
 
   # LSB normal hyperprior
-  dim = 3
+  dim = 2
   mu00 = dim*[1.0]
   sig00 = [1.5*_ for _ in identity_list(dim)]
   step = 0.05
@@ -41,7 +41,7 @@ if __name__ == "__main__":
   lsb_prior.normal_prior.var.data[:] = sig00
   lsb_prior.step_size = step
   lsb_prior.num_components = n_comp
-  with open("resources/asciipb/lsb_normal.asciipb", "w") as f:
+  with open("resources/asciipb/lsb_normal_prior.asciipb", "w") as f:
     PrintMessage(lsb_prior, f)
 
 

--- a/python/generate_asciipb.py
+++ b/python/generate_asciipb.py
@@ -27,6 +27,23 @@ if __name__ == "__main__":
   with open("resources/asciipb/py_fixed.asciipb", "w") as f:
     PrintMessage(py_prior, f)
 
+  # LSB normal hyperprior
+  dim = 3
+  mu00 = dim*[1.0]
+  sig00 = [1.5*_ for _ in identity_list(dim)]
+  step = 0.05
+  n_comp = 3
+  lsb_prior = mixing_prior_pb2.LogSBPrior()
+  lsb_prior.normal_prior.mean.size = len(mu00)
+  lsb_prior.normal_prior.mean.data[:] = mu00
+  lsb_prior.normal_prior.var.rows = int(sqrt(len(sig00)))
+  lsb_prior.normal_prior.var.cols = int(sqrt(len(sig00)))
+  lsb_prior.normal_prior.var.data[:] = sig00
+  lsb_prior.step_size = step
+  lsb_prior.num_components = n_comp
+  with open("resources/asciipb/lsb_normal.asciipb", "w") as f:
+    PrintMessage(lsb_prior, f)
+
 
   # NNIG NGG hyperprior
   nnig_prior = hierarchy_prior_pb2.NNIGPrior()

--- a/python/generate_asciipb.py
+++ b/python/generate_asciipb.py
@@ -29,9 +29,9 @@ if __name__ == "__main__":
 
   # LSB normal hyperprior
   dim = 2
-  mu00 = dim*[1.0]
-  sig00 = [1.5*_ for _ in identity_list(dim)]
-  step = 0.05
+  mu00 = dim*[0.0]
+  sig00 = [5.0*_ for _ in identity_list(dim)]
+  step = 0.025
   n_comp = 3
   lsb_prior = mixing_prior_pb2.LogSBPrior()
   lsb_prior.normal_prior.mean.size = len(mu00)

--- a/python/plot.ipynb
+++ b/python/plot.ipynb
@@ -11,7 +11,12 @@
     "import pandas as pd\n",
     "from mpl_toolkits.mplot3d import Axes3D\n",
     "import scipy.stats as stats\n",
-    "import subprocess"
+    "import subprocess\n",
+    "\n",
+    "# Utility to save files with Unix-like newlines\n",
+    "def save_np(filename, npobj):\n",
+    "    with open(filename, 'wb') as f:\n",
+    "        np.savetxt(f, npobj, fmt='%1.5f')"
    ]
   },
   {
@@ -34,7 +39,7 @@
     "norm1 = np.random.normal(loc=-4.0, scale=1.0, size=int(n/2))\n",
     "norm2 = np.random.normal(loc=+4.0, scale=1.0, size=int(n/2))\n",
     "data_uni = np.concatenate((norm1, norm2))\n",
-    "np.savetxt(\"../resources/csv/in/data_uni.csv\", data_uni, fmt='%1.5f')"
+    "np.savetxt(\"../resources/csv/in/uni_data.csv\", data_uni, fmt='%1.5f')"
    ]
   },
   {
@@ -45,7 +50,7 @@
    "source": [
     "# Generate grid\n",
     "grid_uni = np.arange(-10, +10, 0.1)\n",
-    "np.savetxt(\"../resources/csv/in/grid_uni.csv\", grid_uni, fmt='%1.5f')"
+    "np.savetxt(\"../resources/csv/in/uni_grid.csv\", grid_uni, fmt='%1.5f')"
    ]
   },
   {
@@ -73,7 +78,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Fixed values hyperprior"
+    "## NGG hyperprior"
    ]
   },
   {
@@ -83,15 +88,72 @@
    "outputs": [],
    "source": [
     "# Run the executable\n",
-    "cmd = [\"../build/run\",\n",
-    "    \"Neal8\", str(rng), \"1\", \"6000\", \"5000\",\n",
+    "cmd = (\"../build/run ../algo_settings.asciipb \"\n",
+    "  \"NNIG ../resources/asciipb/nnig_ngg_prior.asciipb \"\n",
+    "  \"DP   ../resources/asciipb/dp_gamma_prior.asciipb '' \"\n",
+    "  \"../resources/csv/in/uni_data.csv ../resources/csv/in/uni_grid.csv \"\n",
+    "  \"../resources/csv/out/uni_dens.csv ../resources/csv/out/uni_nclu.csv \"\n",
+    "  \"../resources/csv/out/uni_clus.csv\").split()\n",
+    "subprocess.run(cmd, capture_output=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = plt.figure(figsize=(21,7))\n",
+    "\n",
+    "# Densities\n",
+    "matr = np.genfromtxt(\"../resources/csv/out/uni_dens.csv\", delimiter=',')\n",
+    "ax1 = fig.add_subplot(131)\n",
+    "for it in iters:\n",
+    "    ax1.plot(grid_uni, np.exp(matr[it, :]), linewidth=0.5)\n",
+    "ax1.plot(grid_uni, np.exp(np.mean(matr, axis=0)), linewidth=1.0,\n",
+    "         linestyle='--', color=\"black\")\n",
+    "\n",
+    "ax1.plot(grid_uni, true_pdf, linewidth=1.0, color=\"red\")\n",
+    "ax1.legend(iters + [\"mean\", \"true\"])\n",
+    "ax1.set_title(\"Univariate densities\")\n",
+    "\n",
+    "# # Total masses\n",
+    "# masses = np.genfromtxt(\"../resources/csv/out/un_mass.csv\", delimiter='\\n')\n",
+    "# ax2 = fig.add_subplot(132)\n",
+    "# ax2.plot(masses)\n",
+    "# ax2.set_title(\"Total masses over iterations\")\n",
+    "\n",
+    "# Number of clusters\n",
+    "num_clust = np.genfromtxt(\"../resources/csv/out/uni_nclu.csv\", delimiter='\\n')\n",
+    "ax3 = fig.add_subplot(133)\n",
+    "ax3.plot(num_clust)\n",
+    "ax3.set_title(\"Number of clusters over iterations\")\n",
+    "\n",
+    "fig.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Fixed values hyperprior (TODO)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Run the executable\n",
+    "cmd = (\"../build/run algo_settings.asciipb\"\n",
     "    \"NNIG\", \"../resources/asciipb/nnig_ngg_prior.asciipb\",\n",
     "    \"DP\", \"../resources/asciipb/dp_gamma_prior.asciipb\",\n",
     "    \"\",\n",
     "    \"../resources/csv/in/data_uni.csv\", \"../resources/csv/in/grid_uni.csv\",\n",
     "    \"../resources/csv/out/uf_dens.csv\", \"../resources/csv/out/uf_mass.csv\",\n",
     "    \"../resources/csv/out/uf_nclu.csv\", \"../resources/csv/out/uf_clus.csv\"\n",
-    "]\n",
+    ").split()\n",
     "subprocess.run(cmd, capture_output=True)"
    ]
   },
@@ -134,77 +196,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## NGG hyperprior"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Run the executable\n",
-    "cmd = [\"../build/run\",\n",
-    "    \"Neal2\", str(rng), \"0\", \"7000\", \"5000\",\n",
-    "    \"NNIG\", \"../resources/asciipb/nnig_ngg_prior.asciipb\",\n",
-    "    \"DP\", \"../resources/asciipb/dp_gamma_prior.asciipb\",\n",
-    "    \"\",\n",
-    "    \"../resources/csv/in/data_uni.csv\", \"../resources/csv/in/grid_uni.csv\",\n",
-    "    \"../resources/csv/out/un_dens.csv\", \"../resources/csv/out/un_mass.csv\",\n",
-    "    \"../resources/csv/out/un_nclu.csv\", \"../resources/csv/out/un_clus.csv\"\n",
-    "]\n",
-    "subprocess.run(cmd, capture_output=True)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "matr.shape"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "fig = plt.figure(figsize=(21,7))\n",
-    "\n",
-    "# Densities\n",
-    "matr = np.genfromtxt(\"../resources/csv/out/un_dens.csv\", delimiter=',')\n",
-    "ax1 = fig.add_subplot(131)\n",
-    "for it in iters:\n",
-    "    ax1.plot(grid_uni, np.exp(matr[it, :]), linewidth=0.5)\n",
-    "ax1.plot(grid_uni, np.exp(np.mean(matr, axis=0)), linewidth=1.0,\n",
-    "         linestyle='--', color=\"black\")\n",
-    "\n",
-    "ax1.plot(grid_uni, true_pdf, linewidth=1.0, color=\"red\")\n",
-    "ax1.legend(iters + [\"mean\", \"true\"])\n",
-    "ax1.set_title(\"Univariate densities\")\n",
-    "\n",
-    "# Total masses\n",
-    "masses = np.genfromtxt(\"../resources/csv/out/un_mass.csv\", delimiter='\\n')\n",
-    "ax2 = fig.add_subplot(132)\n",
-    "ax2.plot(masses)\n",
-    "ax2.set_title(\"Total masses over iterations\")\n",
-    "\n",
-    "# Number of clusters\n",
-    "num_clust = np.genfromtxt(\"../resources/csv/out/un_nclu.csv\", delimiter='\\n')\n",
-    "ax3 = fig.add_subplot(133)\n",
-    "ax3.plot(num_clust)\n",
-    "ax3.set_title(\"Number of clusters over iterations\")\n",
-    "\n",
-    "fig.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Multivariate tests"
+    "# Multivariate tests  (TODO)"
    ]
   },
   {
@@ -362,13 +354,6 @@
    "metadata": {},
    "outputs": [],
    "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -387,7 +372,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.0"
+   "version": "3.8.6"
   }
  },
  "nbformat": 4,

--- a/python/stickbreak.ipynb
+++ b/python/stickbreak.ipynb
@@ -27,8 +27,7 @@
    "source": [
     "# Initialize true parameters\n",
     "dim = 2\n",
-    "alphas = [np.array(dim*[-3]), np.array(dim*[+0]), np.array(dim*[+3])]\n",
-    "sigma2 = 1"
+    "centers = [np.array([-5, 0]), np.array([5, 0]), np.array([0, 5])]"
    ]
   },
   {
@@ -53,12 +52,16 @@
     "rng = 20201124\n",
     "np.random.seed(rng)\n",
     "n = 200\n",
-    "xx = np.random.uniform(low=-2.0, high=3.0, size=(n, dim))\n",
+    "xx = np.zeros((n, dim))\n",
     "cc = int(n/3)*[0] + int(n/3)*[1] + (n - 2*int(n/3))*[2]\n",
     "yy = np.zeros(n)\n",
     "for i in range(n):\n",
-    "    mu = np.dot(xx[i, :], alphas[cc[i]])\n",
-    "    y = np.random.normal(loc=mu, scale=sigma2)\n",
+    "    x = np.random.multivariate_normal(mean=centers[cc[i]],\n",
+    "                                      cov=np.identity(dim))\n",
+    "    xx[i,:] = x\n",
+    "    # mu = np.dot(x, centers[cc[i]])\n",
+    "    mu = 4 * cc[i]\n",
+    "    y = np.random.normal(loc=mu, scale=1) # TODO ?\n",
     "    yy[i] = y\n",
     "# Save to file\n",
     "save_np(\"../resources/csv/in/logsb_cov_mix.csv\", xx)\n",
@@ -72,8 +75,8 @@
    "outputs": [],
    "source": [
     "# Generate grid points\n",
-    "xx_grid = np.matrix(dim*[-2.7])\n",
-    "yy_grid = np.arange(-5.0, +5.1, 0.1)\n",
+    "xx_grid = np.matrix([0, 5])\n",
+    "yy_grid = np.arange(-1, +9.1, 0.5)\n",
     "# Save to file\n",
     "save_np(\"../resources/csv/in/logsb_grid_cov_mix.csv\", xx_grid)\n",
     "save_np(\"../resources/csv/in/logsb_grid_data.csv\", yy_grid)"

--- a/python/stickbreak.ipynb
+++ b/python/stickbreak.ipynb
@@ -19,6 +19,10 @@
     "import subprocess\n",
     "from sklearn.metrics.cluster import adjusted_rand_score\n",
     "from sklearn.model_selection import train_test_split\n",
+    "from google.protobuf.internal.decoder import _DecodeVarint32\n",
+    "import sys\n",
+    "sys.path.insert(0, '..')\n",
+    "from proto.py.algorithm_state_pb2 import AlgorithmState\n",
     "\n",
     "# Utility to save files with Unix-like newlines\n",
     "def save_np(filename, npobj):\n",
@@ -27,7 +31,27 @@
     "\n",
     "# Sigmoid function\n",
     "def sigmoid(x):\n",
-    "    return 1.0 / (1 + np.exp(-x))"
+    "    return 1.0 / (1 + np.exp(-x))\n",
+    "\n",
+    "# Utility to read file collector, courtesy of\n",
+    "# github.com/mberaha/utils/blob/master/proto_utils/py/recordio.py\n",
+    "def readManyFromFile(filename, msgType):\n",
+    "    out = []\n",
+    "    with open(filename, \"rb\") as fp:\n",
+    "        buf = fp.read()\n",
+    "    n = 0\n",
+    "    while n < len(buf):\n",
+    "        msg_len, new_pos = _DecodeVarint32(buf, n)\n",
+    "        n = new_pos\n",
+    "        msg_buf = buf[n:n+msg_len]\n",
+    "        try:\n",
+    "            msg = msgType()\n",
+    "            msg.ParseFromString(msg_buf)\n",
+    "            out.append(msg)\n",
+    "            n += msg_len\n",
+    "        except Exception as e:\n",
+    "            break\n",
+    "    return out"
    ]
   },
   {
@@ -154,7 +178,7 @@
    "source": [
     "cmd = ('../build/run ../algo_settings.asciipb '\n",
     "    'NNIG ../resources/asciipb/nnig_ngg_prior.asciipb '\n",
-    "    'LogSB ../resources/asciipb/lsb_normal_prior.asciipb \"\" '\n",
+    "    'LogSB ../resources/asciipb/lsb_normal_prior.asciipb test1.recordio '\n",
     "    '../resources/csv/in/logsb_data_1.csv ../resources/csv/in/logsb_grid_data_1.csv '\n",
     "    '../resources/csv/out/logsb_dens_1.csv ../resources/csv/out/logsb_nclu_1.csv '\n",
     "    '../resources/csv/out/logsb_clus_1.csv \"\" \"\" '\n",
@@ -293,7 +317,7 @@
    "source": [
     "cmd = ('../build/run ../algo_settings.asciipb '\n",
     "    'NNIG ../resources/asciipb/nnig_ngg_prior.asciipb '\n",
-    "    'LogSB ../resources/asciipb/lsb_normal_prior.asciipb \"\" '\n",
+    "    'LogSB ../resources/asciipb/lsb_normal_prior.asciipb test2.recordio '\n",
     "    '../resources/csv/in/logsb_data_2.csv ../resources/csv/in/logsb_grid_data_2.csv '\n",
     "    '../resources/csv/out/logsb_dens_2.csv ../resources/csv/out/logsb_nclu_2.csv '\n",
     "    '../resources/csv/out/logsb_clus_2.csv \"\" \"\" '\n",
@@ -393,6 +417,70 @@
     "ari2 = adjusted_rand_score(clust2, true_clust2)\n",
     "print(ari1)\n",
     "print(ari2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## File collectors"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Read chain from file collectors:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "chain1 = readManyFromFile(\"../test1.recordio\", AlgorithmState)\n",
+    "chain2 = readManyFromFile(\"../test2.recordio\", AlgorithmState)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For test 1:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for i in range(0, len(chain1), 100):\n",
+    "    means = []\n",
+    "    for j in range(len(chain1[i].cluster_states)):\n",
+    "        means.append(chain1[i].cluster_states[j].uni_ls_state.mean)\n",
+    "    print(means)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For test 2:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for i in range(0, len(chain2), 50):\n",
+    "    means = []\n",
+    "    for j in range(len(chain2[i].cluster_states)):\n",
+    "        means.append(chain2[i].cluster_states[j].uni_ls_state.mean)\n",
+    "    print(means)"
    ]
   },
   {

--- a/python/stickbreak.ipynb
+++ b/python/stickbreak.ipynb
@@ -194,7 +194,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "cmd = ('../build/logsb_run ../algo_settings.asciipb '\n",
+    "cmd = ('../build/dependent_run ../algo_settings.asciipb '\n",
     "    'NNIG ../resources/asciipb/nnig_ngg_prior.asciipb '\n",
     "    'LogSB ../resources/asciipb/lsb_normal_prior.asciipb ../test1.recordio '\n",
     "    '../resources/csv/in/logsb_data_1.csv ../resources/csv/in/logsb_grid_1.csv '\n",
@@ -349,7 +349,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "cmd = ('../build/logsb_run ../algo_settings.asciipb '\n",
+    "cmd = ('../build/dependent_run ../algo_settings.asciipb '\n",
     "    'NNIG ../resources/asciipb/nnig_ngg_prior.asciipb '\n",
     "    'LogSB ../resources/asciipb/lsb_normal_prior.asciipb ../test2.recordio '\n",
     "    '../resources/csv/in/logsb_data_2.csv ../resources/csv/in/logsb_grid_2.csv '\n",

--- a/python/stickbreak.ipynb
+++ b/python/stickbreak.ipynb
@@ -150,6 +150,22 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Generate grid:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "grid1 = np.linspace(-2, 10, 120)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "Save to file:"
    ]
   },
@@ -161,8 +177,8 @@
    "source": [
     "save_np(\"../resources/csv/in/logsb_cov_mix_1.csv\", xx_train1)\n",
     "save_np(\"../resources/csv/in/logsb_data_1.csv\", yy_train1)\n",
-    "save_np(\"../resources/csv/in/logsb_grid_cov_mix_1.csv\", np.matrix(xx_test1[0]))\n",
-    "save_np(\"../resources/csv/in/logsb_grid_data_1.csv\", yy_test1)"
+    "save_np(\"../resources/csv/in/logsb_grid_cov_mix_1.csv\", xx_test1)\n",
+    "save_np(\"../resources/csv/in/logsb_grid_1.csv\", grid1)"
    ]
   },
   {
@@ -178,10 +194,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "cmd = ('../build/run ../algo_settings.asciipb '\n",
+    "cmd = ('../build/logsb_run ../algo_settings.asciipb '\n",
     "    'NNIG ../resources/asciipb/nnig_ngg_prior.asciipb '\n",
-    "    'LogSB ../resources/asciipb/lsb_normal_prior.asciipb test1.recordio '\n",
-    "    '../resources/csv/in/logsb_data_1.csv ../resources/csv/in/logsb_grid_data_1.csv '\n",
+    "    'LogSB ../resources/asciipb/lsb_normal_prior.asciipb ../test1.recordio '\n",
+    "    '../resources/csv/in/logsb_data_1.csv ../resources/csv/in/logsb_grid_1.csv '\n",
     "    '../resources/csv/out/logsb_dens_1.csv ../resources/csv/out/logsb_nclu_1.csv '\n",
     "    '../resources/csv/out/logsb_clus_1.csv \"\" \"\" '\n",
     "    '../resources/csv/in/logsb_cov_mix_1.csv '\n",
@@ -289,6 +305,22 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Generate grid:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "grid2 = np.linspace(-2, 10, 120)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "Save to file:"
    ]
   },
@@ -300,8 +332,8 @@
    "source": [
     "save_np(\"../resources/csv/in/logsb_cov_mix_2.csv\", xx_train2)\n",
     "save_np(\"../resources/csv/in/logsb_data_2.csv\", yy_train2)\n",
-    "save_np(\"../resources/csv/in/logsb_grid_cov_mix_2.csv\", np.matrix(xx_test2[0]))\n",
-    "save_np(\"../resources/csv/in/logsb_grid_data_2.csv\", yy_test2)"
+    "save_np(\"../resources/csv/in/logsb_grid_cov_mix_2.csv\", xx_test2)\n",
+    "save_np(\"../resources/csv/in/logsb_grid_2.csv\", grid2)"
    ]
   },
   {
@@ -317,10 +349,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "cmd = ('../build/run ../algo_settings.asciipb '\n",
+    "cmd = ('../build/logsb_run ../algo_settings.asciipb '\n",
     "    'NNIG ../resources/asciipb/nnig_ngg_prior.asciipb '\n",
-    "    'LogSB ../resources/asciipb/lsb_normal_prior.asciipb test2.recordio '\n",
-    "    '../resources/csv/in/logsb_data_2.csv ../resources/csv/in/logsb_grid_data_2.csv '\n",
+    "    'LogSB ../resources/asciipb/lsb_normal_prior.asciipb ../test2.recordio '\n",
+    "    '../resources/csv/in/logsb_data_2.csv ../resources/csv/in/logsb_grid_2.csv '\n",
     "    '../resources/csv/out/logsb_dens_2.csv ../resources/csv/out/logsb_nclu_2.csv '\n",
     "    '../resources/csv/out/logsb_clus_2.csv \"\" \"\" '\n",
     "    '../resources/csv/in/logsb_cov_mix_2.csv '\n",
@@ -353,10 +385,21 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(matr1.shape)\n",
+    "print(matr2.shape)\n",
+    "# covariates along rows, grid points along columns"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Plot:"
+    "Recover true clustering:"
    ]
   },
   {
@@ -365,13 +408,38 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fig, [ax1, ax2] = plt.subplots(1, 2, figsize=(16,6))\n",
-    "\n",
-    "ax1.scatter(yy_test1, np.exp(np.mean(matr1, axis=0)))\n",
-    "ax1.set_title(f\"Test 1 density\")\n",
-    "\n",
-    "ax2.scatter(yy_test2, np.exp(np.mean(matr2, axis=0)))\n",
-    "ax2.set_title(f\"Test 2 density\")"
+    "true_clust_test1 = cc1[np.where(~training_mask1)[0]]\n",
+    "true_clust_test2 = cc2[np.where(~training_mask2)[0]]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Plots:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "n_covs = 4\n",
+    "covariate_idxs = np.linspace(0, matr1.shape[0]-1, n_covs, dtype=int)\n",
+    "fig = plt.figure(figsize=(16, 8*n_covs))\n",
+    "for i, idx in enumerate(covariate_idxs):\n",
+    "    ax1 = fig.add_subplot(n_covs, 2, 2*i+1)\n",
+    "    ax1.set_title(\n",
+    "        f\"Test 1 covariate {idx}, true cluster = {true_clust_test1[idx]}\")\n",
+    "    ax1.plot(grid1, np.exp(matr1[idx, :]))\n",
+    "    ax1.scatter(yy_test1[idx], 0)\n",
+    "    \n",
+    "    ax2 = fig.add_subplot(n_covs, 2, 2*i+2)\n",
+    "    ax2.set_title(\n",
+    "        f\"Test 2 covariate {idx}, true cluster = {true_clust_test2[idx]}\")\n",
+    "    ax2.plot(grid2, np.exp(matr2[idx, :]))\n",
+    "    ax2.scatter(yy_test2[idx], 0)"
    ]
   },
   {

--- a/python/stickbreak.ipynb
+++ b/python/stickbreak.ipynb
@@ -16,7 +16,8 @@
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
     "import pandas as pd\n",
-    "import subprocess"
+    "import subprocess\n",
+    "from sklearn.metrics.cluster import adjusted_rand_score"
    ]
   },
   {
@@ -118,7 +119,7 @@
     "    '../resources/csv/in/logsb_data_1.csv ../resources/csv/in/logsb_grid_data_1.csv '\n",
     "    '../resources/csv/out/logsb_dens_1.csv ../resources/csv/out/logsb_nclu_1.csv '\n",
     "    '../resources/csv/out/logsb_clus_1.csv \"\" \"\" '\n",
-    "    '../resources/csv/in/logsb_cov_mix_1.csv \n",
+    "    '../resources/csv/in/logsb_cov_mix_1.csv '\n",
     "    '../resources/csv/in/logsb_grid_cov_mix_1.csv').split()\n",
     "subprocess.run(cmd, capture_output=True)"
    ]
@@ -218,7 +219,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "matr = np.genfromtxt(\"../resources/csv/out/logsb_dens.csv\", delimiter=',')"
+    "# matr = np.genfromtxt(\"../resources/csv/out/logsb_dens.csv\", delimiter=',')"
    ]
   },
   {
@@ -235,11 +236,20 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Rand scores"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "# adjusted_rand_score(cl1.astype(int), cl2.astype(int))"
+   ]
   }
  ],
  "metadata": {

--- a/python/stickbreak.ipynb
+++ b/python/stickbreak.ipynb
@@ -15,11 +15,8 @@
    "source": [
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
-    "import subprocess\n",
-    "# from google.protobuf.internal.decoder import _DecodeVarint32\n",
-    "import sys\n",
-    "sys.path.insert(0, '..')\n",
-    "# from proto.py.algorithm_state_pb2 import AlgorithmState"
+    "import pandas as pd\n",
+    "import subprocess"
    ]
   },
   {
@@ -76,8 +73,7 @@
    "source": [
     "# Generate grid points\n",
     "xx_grid = np.matrix(dim*[-2.7])\n",
-    "lin = np.arange(-4.0, +4.1, 0.5)\n",
-    "yy_grid = np.array(np.meshgrid(lin, lin)).T.reshape(-1, 2)\n",
+    "yy_grid = np.arange(-5.0, +5.1, 0.1)\n",
     "# Save to file\n",
     "save_np(\"../resources/csv/in/logsb_grid_cov_mix.csv\", xx_grid)\n",
     "save_np(\"../resources/csv/in/logsb_grid_data.csv\", yy_grid)"
@@ -89,17 +85,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Run the executable # TODO\n",
-    "cmd = [\"../build/run\",\n",
-    "    \"Neal2\", str(rng), \"0\", \"1000\", \"100\",\n",
-    "    \"LinRegUni\", \"../resources/asciipb/lin_reg_uni_fixed.asciipb\",\n",
-    "    \"DP\", \"../resources/asciipb/dp_gamma_prior.asciipb\",\n",
-    "    \"../lru.recordio\",\n",
-    "    \"../resources/csv/in/data_lru.csv\",  \"../resources/csv/in/covs_grid_lru.csv\",\n",
-    "    \"../resources/csv/out/lru_dens.csv\", \"../resources/csv/out/lru_mass.csv\",\n",
-    "    \"../resources/csv/out/lru_nclu.csv\", \"../resources/csv/out/lru_clus.csv\",\n",
-    "    \"../resources/csv/in/covs_lru.csv\",  \"../resources/csv/in/covs_grid_lru.csv\"\n",
-    "]\n",
+    "# Run the executable\n",
+    "cmd = ('../build/run ../algo_settings.asciipb '\n",
+    "    'NNIG ../resources/asciipb/nnig_ngg_prior.asciipb '\n",
+    "    'LogSB ../resources/asciipb/lsb_normal_prior.asciipb \"\" '\n",
+    "    '../resources/csv/in/logsb_data.csv ../resources/csv/in/logsb_grid_data.csv '\n",
+    "    '../resources/csv/out/logsb_dens.csv ../resources/csv/out/logsb_nclu.csv '\n",
+    "    '../resources/csv/out/logsb_clus.csv \"\" \"\" '\n",
+    "    '../resources/csv/in/logsb_cov_mix.csv \n",
+    "    '../resources/csv/in/logsb_grid_cov_mix.csv').split()\n",
     "subprocess.run(cmd, capture_output=True)"
    ]
   },
@@ -107,7 +101,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Simulation study"
+    "## Plot density"
    ]
   },
   {
@@ -116,25 +110,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Utility to read file collector, courtesy of\n",
-    "# github.com/mberaha/utils/blob/master/proto_utils/py/recordio.py\n",
-    "def readManyFromFile(filename, msgType):\n",
-    "    out = []\n",
-    "    with open(filename, \"rb\") as fp:\n",
-    "        buf = fp.read()\n",
-    "    n = 0\n",
-    "    while n < len(buf):\n",
-    "        msg_len, new_pos = _DecodeVarint32(buf, n)\n",
-    "        n = new_pos\n",
-    "        msg_buf = buf[n:n+msg_len]\n",
-    "        try:\n",
-    "            msg = msgType()\n",
-    "            msg.ParseFromString(msg_buf)\n",
-    "            out.append(msg)\n",
-    "            n += msg_len\n",
-    "        except Exception as e:\n",
-    "            break\n",
-    "    return out"
+    "matr = np.genfromtxt(\"../resources/csv/out/logsb_dens.csv\", delimiter=',')"
    ]
   },
   {
@@ -143,78 +119,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Read chain\n",
-    "chain = readManyFromFile('../lru.recordio', MarginalState)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Compare original betas and regression betas of some iterations:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "betas_print = []\n",
-    "for i in (0, 2, 1):\n",
-    "    betas_print.append([\"%1.1f\"%float(b) for b in betas[i]])\n",
-    "\n",
-    "print(\"Original betas:\")\n",
-    "print(betas_print)\n",
-    "\n",
-    "print(\"Chain betas of iterations with 3 clusters:\")\n",
-    "for state in chain:\n",
-    "    if len(state.cluster_states) == 3:\n",
-    "        betas_chain = []\n",
-    "        for clus in state.cluster_states:\n",
-    "            beta = clus.lin_reg_univ_ls_state.regression_coeffs.data\n",
-    "            betas_chain.append([\"%1.1f\"%b for b in beta])\n",
-    "        print(betas_chain, f\"(iteration n. {state.iteration_num})\", sep=\"\\t\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Compare true and posterior clustering:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Read posterior clustering\n",
-    "cc_post = np.loadtxt('../resources/csv/out/lru_clus.csv')\n",
-    "cc_post = [int(_) for _ in cc_post]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "idxs = [i for i in range(n)]\n",
-    "\n",
-    "size_true = len(set(cc))\n",
-    "cmap1 = plt.cm.get_cmap('hsv', size_true+1)\n",
-    "f, (ax1, ax2) = plt.subplots(1, 2, figsize=(18,5))\n",
-    "for i in idxs:\n",
-    "    ax1.scatter(i, i, color=cmap1(cc[i]))\n",
-    "ax1.set_title(f\"True clustering, with {size_true} clusters\")\n",
-    "\n",
-    "size_post = len(set(cc_post))\n",
-    "cmap2 = plt.cm.get_cmap('hsv', size_post+1)\n",
-    "for i in idxs:\n",
-    "    ax2.scatter(i, i, color=cmap2(cc_post[i]))\n",
-    "ax2.set_title(f\"Posterior clustering, with {size_post} clusters\")"
+    "plt.plot(yy_grid, np.exp(matr[5,:]))\n",
+    "plt.plot(yy_grid, np.exp(matr[29,:]))\n",
+    "plt.plot(yy_grid, np.exp(matr[400,:]))\n",
+    "plt.plot(yy_grid, np.exp(np.mean(matr, axis=0)), linestyle='--')\n",
+    "plt.title(\"Densities\")"
    ]
   },
   {

--- a/python/stickbreak.ipynb
+++ b/python/stickbreak.ipynb
@@ -112,7 +112,7 @@
     "# Save to file\n",
     "save_np(\"../resources/csv/in/logsb_cov_mix_1.csv\", xx_train)\n",
     "save_np(\"../resources/csv/in/logsb_data_1.csv\", yy_train)\n",
-    "save_np(\"../resources/csv/in/logsb_grid_cov_mix_1.csv\", xx_test)\n",
+    "save_np(\"../resources/csv/in/logsb_grid_cov_mix_1.csv\", np.matrix(xx_test[0]))\n",
     "save_np(\"../resources/csv/in/logsb_grid_data_1.csv\", yy_test)"
    ]
   },
@@ -226,7 +226,7 @@
     "# Save to file\n",
     "save_np(\"../resources/csv/in/logsb_cov_mix_2.csv\", xx_train2)\n",
     "save_np(\"../resources/csv/in/logsb_data_2.csv\", yy_train2)\n",
-    "save_np(\"../resources/csv/in/logsb_grid_cov_mix_2.csv\", xx_test2)\n",
+    "save_np(\"../resources/csv/in/logsb_grid_cov_mix_2.csv\", np.matrix(xx_test2[0]))\n",
     "save_np(\"../resources/csv/in/logsb_grid_data_2.csv\", yy_test2)"
    ]
   },

--- a/python/stickbreak.ipynb
+++ b/python/stickbreak.ipynb
@@ -50,13 +50,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dim = 2\n",
-    "n_clus = 3\n",
-    "x_centers = np.column_stack(([-5, 0], [5, 0], [0, 5]))\n",
-    "x_var = (1.5)**2\n",
-    "y_centers = [4*_ for _ in range(dim+1)]\n",
-    "y_var = 1\n",
-    "weights = [0.2, 0.2, 0.6]"
+    "dim1 = 2\n",
+    "n_clus1 = 3\n",
+    "x_centers1 = np.column_stack(([-5, 0], [5, 0], [0, 5]))\n",
+    "x_var1 = (1.5)**2\n",
+    "y_centers1 = [4*_ for _ in range(n_clus1)]\n",
+    "y_var1 = 1\n",
+    "weights1 = [0.2, 0.2, 0.6]"
    ]
   },
   {
@@ -72,24 +72,24 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "n = 200\n",
+    "n1 = 200\n",
     "np.random.seed(20201124)\n",
     "# Allocations\n",
-    "cc = []\n",
-    "for c in range(n_clus):\n",
-    "    nn = int(weights[c] * n)\n",
-    "    cc.extend(nn * [c])\n",
+    "cc1 = []\n",
+    "for c in range(n_clus1):\n",
+    "    nn = int(weights1[c] * n1)\n",
+    "    cc1.extend(nn * [c])\n",
     "# Covariates\n",
-    "xx = np.zeros((n, dim))\n",
-    "for i in range(n):\n",
-    "    x = np.random.multivariate_normal(mean=x_centers[:,cc[i]],\n",
-    "                                      cov=x_var*np.identity(dim))\n",
-    "    xx[i,:] = x\n",
+    "xx1 = np.zeros((n1, dim1))\n",
+    "for i in range(n1):\n",
+    "    x = np.random.multivariate_normal(mean=x_centers1[:,cc1[i]],\n",
+    "        cov=x_var1*np.identity(dim1))\n",
+    "    xx1[i,:] = x\n",
     "# Data points\n",
-    "yy = np.zeros(n)\n",
-    "for i in range(n):\n",
-    "    y = np.random.normal(loc=y_centers[cc[i]], scale=y_var)\n",
-    "    yy[i] = y"
+    "yy1 = np.zeros(n1)\n",
+    "for i in range(n1):\n",
+    "    y = np.random.normal(loc=y_centers1[cc1[i]], scale=y_var1)\n",
+    "    yy1[i] = y"
    ]
   },
   {
@@ -105,15 +105,38 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "np.random.seed(20201124)\n",
-    "perc_test = 0.25\n",
-    "xx_train, xx_test, yy_train, yy_test = train_test_split(xx, yy,\n",
-    "    test_size=perc_test, shuffle=False)\n",
-    "# Save to file\n",
-    "save_np(\"../resources/csv/in/logsb_cov_mix_1.csv\", xx_train)\n",
-    "save_np(\"../resources/csv/in/logsb_data_1.csv\", yy_train)\n",
-    "save_np(\"../resources/csv/in/logsb_grid_cov_mix_1.csv\", np.matrix(xx_test[0]))\n",
-    "save_np(\"../resources/csv/in/logsb_grid_data_1.csv\", yy_test)"
+    "np.random.seed(20201125)\n",
+    "perc_train1 = 0.75\n",
+    "# Generate booleans\n",
+    "n_train1 = int(perc_train1 * n1)\n",
+    "idxs1 = np.arange(n1)\n",
+    "training_mask1 = np.zeros(n1, dtype=bool)\n",
+    "train_idxs1 = np.random.choice(idxs1, size=n_train1, replace=False)\n",
+    "training_mask1[train_idxs1] = True\n",
+    "# Train and test sets\n",
+    "xx_train1 = xx1[training_mask1]\n",
+    "yy_train1 = yy1[training_mask1]\n",
+    "xx_test1 = xx1[~training_mask1]\n",
+    "yy_test1 = yy1[~training_mask1]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Save to file:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "save_np(\"../resources/csv/in/logsb_cov_mix_1.csv\", xx_train1)\n",
+    "save_np(\"../resources/csv/in/logsb_data_1.csv\", yy_train1)\n",
+    "save_np(\"../resources/csv/in/logsb_grid_cov_mix_1.csv\", np.matrix(xx_test1[0]))\n",
+    "save_np(\"../resources/csv/in/logsb_grid_data_1.csv\", yy_test1)"
    ]
   },
   {
@@ -160,12 +183,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dim2 = 3\n",
-    "n_clus2 = 4\n",
-    "alphas = np.identity(n_clus2-1)\n",
-    "x_mean = np.array(dim2*[1])\n",
+    "dim2 = 2\n",
+    "n_clus2 = 3\n",
+    "alphas2 = np.identity(n_clus2-1)\n",
+    "x_mean2 = np.array(dim2*[1])\n",
     "x_var2 = (1.5)**2\n",
-    "y_centers2 = [4*_ for _ in range(dim2+1)]\n",
+    "y_centers2 = [4*_ for _ in range(n_clus2)]\n",
     "y_var2 = 1"
    ]
   },
@@ -182,18 +205,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "np.random.seed(20201124)\n",
+    "np.random.seed(20201126)\n",
     "n2 = 200\n",
     "# Covariates\n",
-    "xx2 = np.random.multivariate_normal(mean=x_mean,\n",
+    "xx2 = np.random.multivariate_normal(mean=x_mean2,\n",
     "    cov=x_var2*np.identity(dim2), size=n2)\n",
     "# Data points\n",
     "yy2 = np.zeros(n2)\n",
+    "cc2 = np.zeros(n2, dtype=int)\n",
     "for i in range(n2):\n",
     "    ## Generate nu_h(xi)\n",
     "    nu = np.zeros(n_clus2-1)\n",
     "    for h in range(n_clus2-1):\n",
-    "        nu[h] = sigmoid(np.dot(alphas[:, h], xx2[i]))\n",
+    "        nu[h] = sigmoid(np.dot(alphas2[:, h], xx2[i]))\n",
     "    ## Generate weights\n",
     "    weights = np.zeros(n_clus2)\n",
     "    for h in range(n_clus2-1):\n",
@@ -203,6 +227,7 @@
     "    weights[n_clus2-1] = 1 - weights[:n_clus2-1].sum()\n",
     "    ## Choose cluster and generate yi\n",
     "    c = np.random.choice(n_clus2, p=weights)\n",
+    "    cc2[i] = c\n",
     "    yy2[i] = np.random.normal(loc=y_centers2[c], scale=y_var2)"
    ]
   },
@@ -219,11 +244,34 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "np.random.seed(20201124)\n",
-    "perc_test2 = 0.25\n",
-    "xx_train2, xx_test2, yy_train2, yy_test2 = train_test_split(xx2, yy2,\n",
-    "    test_size=perc_test2, shuffle=False)\n",
-    "# Save to file\n",
+    "np.random.seed(20201127)\n",
+    "perc_train2 = 0.75\n",
+    "# Generate booleans\n",
+    "n_train2 = int(0.75 * n2)\n",
+    "idxs2 = np.arange(n2)\n",
+    "training_mask2 = np.zeros(n2, dtype=bool)\n",
+    "train_idxs2 = np.random.choice(idxs2, size=n_train2, replace=False)\n",
+    "training_mask2[train_idxs2] = True\n",
+    "# Train and test sets\n",
+    "xx_train2 = xx2[training_mask2]\n",
+    "yy_train2 = yy2[training_mask2]\n",
+    "xx_test2 = xx2[~training_mask2]\n",
+    "yy_test2 = yy2[~training_mask2]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Save to file:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "save_np(\"../resources/csv/in/logsb_cov_mix_2.csv\", xx_train2)\n",
     "save_np(\"../resources/csv/in/logsb_data_2.csv\", yy_train2)\n",
     "save_np(\"../resources/csv/in/logsb_grid_cov_mix_2.csv\", np.matrix(xx_test2[0]))\n",
@@ -258,36 +306,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Plot density"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# matr = np.genfromtxt(\"../resources/csv/out/logsb_dens.csv\", delimiter=',')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "plt.plot(yy_grid, np.exp(matr[5,:]))\n",
-    "plt.plot(yy_grid, np.exp(matr[29,:]))\n",
-    "plt.plot(yy_grid, np.exp(matr[400,:]))\n",
-    "plt.plot(yy_grid, np.exp(np.mean(matr, axis=0)), linestyle='--')\n",
-    "plt.title(\"Densities\")"
+    "## Plot densities on test sets"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Rand scores"
+    "Read density matrices:"
    ]
   },
   {
@@ -296,8 +322,85 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# adjusted_rand_score(cl1.astype(int), cl2.astype(int))"
+    "matr1 = np.genfromtxt(\"../resources/csv/out/logsb_dens_1.csv\", delimiter=',')\n",
+    "matr2 = np.genfromtxt(\"../resources/csv/out/logsb_dens_2.csv\", delimiter=',')"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Plot:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, [ax1, ax2] = plt.subplots(1, 2, figsize=(16,6))\n",
+    "\n",
+    "ax1.scatter(yy_test1, np.exp(np.mean(matr1, axis=0)))\n",
+    "ax1.set_title(f\"Test 1 density\")\n",
+    "\n",
+    "ax2.scatter(yy_test2, np.exp(np.mean(matr2, axis=0)))\n",
+    "ax2.set_title(f\"Test 2 density\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Compare clustering on train sets"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Read posterior clusterings:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clust1 = np.genfromtxt(\"../resources/csv/out/logsb_clus_1.csv\",\n",
+    "    delimiter=',').astype(int)\n",
+    "clust2 = np.genfromtxt(\"../resources/csv/out/logsb_clus_2.csv\",\n",
+    "    delimiter=',').astype(int)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Compute Adjusted Rand Indexes by comparison with true clustering:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "true_clust1 = [cc1[i] for i in train_idxs1]\n",
+    "true_clust2 = [cc2[i] for i in train_idxs2]\n",
+    "ari1 = adjusted_rand_score(clust1, true_clust1)\n",
+    "ari2 = adjusted_rand_score(clust2, true_clust2)\n",
+    "print(ari1)\n",
+    "print(ari2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/python/stickbreak.ipynb
+++ b/python/stickbreak.ipynb
@@ -476,7 +476,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "for i in range(0, len(chain2), 50):\n",
+    "for i in range(0, len(chain2), 100):\n",
     "    means = []\n",
     "    for j in range(len(chain2[i].cluster_states)):\n",
     "        means.append(chain2[i].cluster_states[j].uni_ls_state.mean)\n",

--- a/python/stickbreak.ipynb
+++ b/python/stickbreak.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Bayesian linear regression"
+    "# Blocked Gibbs algorithm + logit SB mixing"
    ]
   },
   {
@@ -25,17 +25,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Initialize true parameters\n",
-    "dim = 2\n",
-    "centers = [np.array([-5, 0]), np.array([5, 0]), np.array([0, 5])]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "# Utility to save files with Unix-like newlines\n",
     "def save_np(filename, npobj):\n",
     "    with open(filename, 'wb') as f:\n",
@@ -43,29 +32,63 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Test 1"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Generate data\n",
+    "# Initialize true parameters\n",
+    "dim = 2\n",
+    "n_clus = 3\n",
+    "x_centers = np.column_stack(([-5, 0], [5, 0], [0, 5]))\n",
+    "x_var = (1.5)**2\n",
+    "y_centers = [4*_ for _ in range(dim+1)]\n",
+    "y_var = 1\n",
+    "weights = [0.2, 0.2, 0.6]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Generate data:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "n = 200\n",
     "rng = 20201124\n",
     "np.random.seed(rng)\n",
-    "n = 200\n",
+    "# Allocations\n",
+    "cc = []\n",
+    "for c in range(n_clus):\n",
+    "    nn = int(weights[c] * n)\n",
+    "    cc.extend(nn * [c])\n",
+    "# Covariates\n",
     "xx = np.zeros((n, dim))\n",
-    "cc = int(n/3)*[0] + int(n/3)*[1] + (n - 2*int(n/3))*[2]\n",
+    "for i in range(n):\n",
+    "    x = np.random.multivariate_normal(mean=x_centers[:,cc[i]],\n",
+    "                                      cov=x_var*np.identity(dim))\n",
+    "    xx[i,:] = x\n",
+    "# Data points\n",
     "yy = np.zeros(n)\n",
     "for i in range(n):\n",
-    "    x = np.random.multivariate_normal(mean=centers[cc[i]],\n",
-    "                                      cov=np.identity(dim))\n",
-    "    xx[i,:] = x\n",
-    "    # mu = np.dot(x, centers[cc[i]])\n",
-    "    mu = 4 * cc[i]\n",
-    "    y = np.random.normal(loc=mu, scale=1) # TODO ?\n",
+    "    y = np.random.normal(loc=y_centers[cc[i]], scale=y_var)\n",
     "    yy[i] = y\n",
     "# Save to file\n",
-    "save_np(\"../resources/csv/in/logsb_cov_mix.csv\", xx)\n",
-    "save_np(\"../resources/csv/in/logsb_data.csv\", yy)"
+    "save_np(\"../resources/csv/in/logsb_cov_mix_1.csv\", xx)\n",
+    "save_np(\"../resources/csv/in/logsb_data_1.csv\", yy)"
    ]
   },
   {
@@ -76,10 +99,10 @@
    "source": [
     "# Generate grid points\n",
     "xx_grid = np.matrix([0, 5])\n",
-    "yy_grid = np.arange(-1, +9.1, 0.5)\n",
+    "yy_grid = np.arange(-2, +10.1, 0.5)\n",
     "# Save to file\n",
-    "save_np(\"../resources/csv/in/logsb_grid_cov_mix.csv\", xx_grid)\n",
-    "save_np(\"../resources/csv/in/logsb_grid_data.csv\", yy_grid)"
+    "save_np(\"../resources/csv/in/logsb_grid_cov_mix_1.csv\", xx_grid)\n",
+    "save_np(\"../resources/csv/in/logsb_grid_data_1.csv\", yy_grid)"
    ]
   },
   {
@@ -92,12 +115,94 @@
     "cmd = ('../build/run ../algo_settings.asciipb '\n",
     "    'NNIG ../resources/asciipb/nnig_ngg_prior.asciipb '\n",
     "    'LogSB ../resources/asciipb/lsb_normal_prior.asciipb \"\" '\n",
-    "    '../resources/csv/in/logsb_data.csv ../resources/csv/in/logsb_grid_data.csv '\n",
-    "    '../resources/csv/out/logsb_dens.csv ../resources/csv/out/logsb_nclu.csv '\n",
-    "    '../resources/csv/out/logsb_clus.csv \"\" \"\" '\n",
-    "    '../resources/csv/in/logsb_cov_mix.csv \n",
-    "    '../resources/csv/in/logsb_grid_cov_mix.csv').split()\n",
+    "    '../resources/csv/in/logsb_data_1.csv ../resources/csv/in/logsb_grid_data_1.csv '\n",
+    "    '../resources/csv/out/logsb_dens_1.csv ../resources/csv/out/logsb_nclu_1.csv '\n",
+    "    '../resources/csv/out/logsb_clus_1.csv \"\" \"\" '\n",
+    "    '../resources/csv/in/logsb_cov_mix_1.csv \n",
+    "    '../resources/csv/in/logsb_grid_cov_mix_1.csv').split()\n",
     "subprocess.run(cmd, capture_output=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Test 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def sigmoid(x):\n",
+    "    return 1.0 / (1 + np.exp(-x))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dim2 = 3\n",
+    "n_clus2 = 4\n",
+    "alphas = np.identity(n_clus2-1)\n",
+    "x_mean = np.array(dim2*[1])\n",
+    "x_var2 = (1.5)**2\n",
+    "y_centers2 = [4*_ for _ in range(dim2+1)]\n",
+    "y_var2 = 1"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Generate data:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "n2 = 200\n",
+    "rng2 = 20201124\n",
+    "np.random.seed(rng2)\n",
+    "# Covariates\n",
+    "xx2 = np.random.multivariate_normal(mean=x_mean,\n",
+    "                                    cov=x_var2*np.identity(dim2),\n",
+    "                                    size=n2)\n",
+    "# Data points\n",
+    "yy2 = np.zeros(n2)\n",
+    "for i in range(n2):\n",
+    "    ## Generate nu_h(xi)\n",
+    "    nu = np.zeros(n_clus2-1)\n",
+    "    for h in range(n_clus2-1):\n",
+    "        nu[h] = sigmoid(np.dot(alphas[:, h], xx2[i]))\n",
+    "    ## Generate weights\n",
+    "    weights = np.zeros(n_clus2)\n",
+    "    for h in range(n_clus2-1):\n",
+    "        weights[h] = nu[h]\n",
+    "        for k in range(h):\n",
+    "            weights[h] *= 1-nu[k]\n",
+    "    weights[n_clus2-1] = 1 - weights[:n_clus2-1].sum()\n",
+    "    ## Choose cluster and generate yi\n",
+    "    c = np.random.choice(n_clus2, p=weights)\n",
+    "    yy2[i] = np.random.normal(loc=y_centers2[c], scale=y_var2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Save to file\n",
+    "save_np(\"../resources/csv/in/logsb_cov_mix_2.csv\", xx2)\n",
+    "save_np(\"../resources/csv/in/logsb_data_2.csv\", yy2)"
    ]
   },
   {

--- a/python/stickbreak.ipynb
+++ b/python/stickbreak.ipynb
@@ -1,0 +1,249 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Bayesian linear regression"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "import subprocess\n",
+    "# from google.protobuf.internal.decoder import _DecodeVarint32\n",
+    "import sys\n",
+    "sys.path.insert(0, '..')\n",
+    "# from proto.py.algorithm_state_pb2 import AlgorithmState"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Initialize true parameters\n",
+    "dim = 2\n",
+    "alphas = [np.array(dim*[-3]), np.array(dim*[+0]), np.array(dim*[+3])]\n",
+    "sigma2 = 1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Utility to save files with Unix-like newlines\n",
+    "def save_np(filename, npobj):\n",
+    "    with open(filename, 'wb') as f:\n",
+    "        np.savetxt(f, npobj, fmt='%1.5f')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Generate data\n",
+    "rng = 20201124\n",
+    "np.random.seed(rng)\n",
+    "n = 200\n",
+    "xx = np.random.uniform(low=-2.0, high=3.0, size=(n, dim))\n",
+    "cc = int(n/3)*[0] + int(n/3)*[1] + (n - 2*int(n/3))*[2]\n",
+    "yy = np.zeros(n)\n",
+    "for i in range(n):\n",
+    "    mu = np.dot(xx[i, :], alphas[cc[i]])\n",
+    "    y = np.random.normal(loc=mu, scale=sigma2)\n",
+    "    yy[i] = y\n",
+    "# Save to file\n",
+    "save_np(\"../resources/csv/in/logsb_cov_mix.csv\", xx)\n",
+    "save_np(\"../resources/csv/in/logsb_data.csv\", yy)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Generate grid points\n",
+    "xx_grid = np.matrix(dim*[-2.7])\n",
+    "lin = np.arange(-4.0, +4.1, 0.5)\n",
+    "yy_grid = np.array(np.meshgrid(lin, lin)).T.reshape(-1, 2)\n",
+    "# Save to file\n",
+    "save_np(\"../resources/csv/in/logsb_grid_cov_mix.csv\", xx_grid)\n",
+    "save_np(\"../resources/csv/in/logsb_grid_data.csv\", yy_grid)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Run the executable # TODO\n",
+    "cmd = [\"../build/run\",\n",
+    "    \"Neal2\", str(rng), \"0\", \"1000\", \"100\",\n",
+    "    \"LinRegUni\", \"../resources/asciipb/lin_reg_uni_fixed.asciipb\",\n",
+    "    \"DP\", \"../resources/asciipb/dp_gamma_prior.asciipb\",\n",
+    "    \"../lru.recordio\",\n",
+    "    \"../resources/csv/in/data_lru.csv\",  \"../resources/csv/in/covs_grid_lru.csv\",\n",
+    "    \"../resources/csv/out/lru_dens.csv\", \"../resources/csv/out/lru_mass.csv\",\n",
+    "    \"../resources/csv/out/lru_nclu.csv\", \"../resources/csv/out/lru_clus.csv\",\n",
+    "    \"../resources/csv/in/covs_lru.csv\",  \"../resources/csv/in/covs_grid_lru.csv\"\n",
+    "]\n",
+    "subprocess.run(cmd, capture_output=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Simulation study"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Utility to read file collector, courtesy of\n",
+    "# github.com/mberaha/utils/blob/master/proto_utils/py/recordio.py\n",
+    "def readManyFromFile(filename, msgType):\n",
+    "    out = []\n",
+    "    with open(filename, \"rb\") as fp:\n",
+    "        buf = fp.read()\n",
+    "    n = 0\n",
+    "    while n < len(buf):\n",
+    "        msg_len, new_pos = _DecodeVarint32(buf, n)\n",
+    "        n = new_pos\n",
+    "        msg_buf = buf[n:n+msg_len]\n",
+    "        try:\n",
+    "            msg = msgType()\n",
+    "            msg.ParseFromString(msg_buf)\n",
+    "            out.append(msg)\n",
+    "            n += msg_len\n",
+    "        except Exception as e:\n",
+    "            break\n",
+    "    return out"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Read chain\n",
+    "chain = readManyFromFile('../lru.recordio', MarginalState)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Compare original betas and regression betas of some iterations:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "betas_print = []\n",
+    "for i in (0, 2, 1):\n",
+    "    betas_print.append([\"%1.1f\"%float(b) for b in betas[i]])\n",
+    "\n",
+    "print(\"Original betas:\")\n",
+    "print(betas_print)\n",
+    "\n",
+    "print(\"Chain betas of iterations with 3 clusters:\")\n",
+    "for state in chain:\n",
+    "    if len(state.cluster_states) == 3:\n",
+    "        betas_chain = []\n",
+    "        for clus in state.cluster_states:\n",
+    "            beta = clus.lin_reg_univ_ls_state.regression_coeffs.data\n",
+    "            betas_chain.append([\"%1.1f\"%b for b in beta])\n",
+    "        print(betas_chain, f\"(iteration n. {state.iteration_num})\", sep=\"\\t\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Compare true and posterior clustering:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Read posterior clustering\n",
+    "cc_post = np.loadtxt('../resources/csv/out/lru_clus.csv')\n",
+    "cc_post = [int(_) for _ in cc_post]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "idxs = [i for i in range(n)]\n",
+    "\n",
+    "size_true = len(set(cc))\n",
+    "cmap1 = plt.cm.get_cmap('hsv', size_true+1)\n",
+    "f, (ax1, ax2) = plt.subplots(1, 2, figsize=(18,5))\n",
+    "for i in idxs:\n",
+    "    ax1.scatter(i, i, color=cmap1(cc[i]))\n",
+    "ax1.set_title(f\"True clustering, with {size_true} clusters\")\n",
+    "\n",
+    "size_post = len(set(cc_post))\n",
+    "cmap2 = plt.cm.get_cmap('hsv', size_post+1)\n",
+    "for i in idxs:\n",
+    "    ax2.scatter(i, i, color=cmap2(cc_post[i]))\n",
+    "ax2.set_title(f\"Posterior clustering, with {size_post} clusters\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/python/stickbreak.ipynb
+++ b/python/stickbreak.ipynb
@@ -17,19 +17,17 @@
     "import matplotlib.pyplot as plt\n",
     "import pandas as pd\n",
     "import subprocess\n",
-    "from sklearn.metrics.cluster import adjusted_rand_score"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "from sklearn.metrics.cluster import adjusted_rand_score\n",
+    "from sklearn.model_selection import train_test_split\n",
+    "\n",
     "# Utility to save files with Unix-like newlines\n",
     "def save_np(filename, npobj):\n",
     "    with open(filename, 'wb') as f:\n",
-    "        np.savetxt(f, npobj, fmt='%1.5f')"
+    "        np.savetxt(f, npobj, fmt='%1.5f')\n",
+    "\n",
+    "# Sigmoid function\n",
+    "def sigmoid(x):\n",
+    "    return 1.0 / (1 + np.exp(-x))"
    ]
   },
   {
@@ -40,12 +38,18 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Initialize parameters:"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Initialize true parameters\n",
     "dim = 2\n",
     "n_clus = 3\n",
     "x_centers = np.column_stack(([-5, 0], [5, 0], [0, 5]))\n",
@@ -69,8 +73,7 @@
    "outputs": [],
    "source": [
     "n = 200\n",
-    "rng = 20201124\n",
-    "np.random.seed(rng)\n",
+    "np.random.seed(20201124)\n",
     "# Allocations\n",
     "cc = []\n",
     "for c in range(n_clus):\n",
@@ -86,10 +89,14 @@
     "yy = np.zeros(n)\n",
     "for i in range(n):\n",
     "    y = np.random.normal(loc=y_centers[cc[i]], scale=y_var)\n",
-    "    yy[i] = y\n",
-    "# Save to file\n",
-    "save_np(\"../resources/csv/in/logsb_cov_mix_1.csv\", xx)\n",
-    "save_np(\"../resources/csv/in/logsb_data_1.csv\", yy)"
+    "    yy[i] = y"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Split into train and test sets:"
    ]
   },
   {
@@ -98,12 +105,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Generate grid points\n",
-    "xx_grid = np.matrix([0, 5])\n",
-    "yy_grid = np.arange(-2, +10.1, 0.5)\n",
+    "np.random.seed(20201124)\n",
+    "perc_test = 0.25\n",
+    "xx_train, xx_test, yy_train, yy_test = train_test_split(xx, yy,\n",
+    "    test_size=perc_test, shuffle=False)\n",
     "# Save to file\n",
-    "save_np(\"../resources/csv/in/logsb_grid_cov_mix_1.csv\", xx_grid)\n",
-    "save_np(\"../resources/csv/in/logsb_grid_data_1.csv\", yy_grid)"
+    "save_np(\"../resources/csv/in/logsb_cov_mix_1.csv\", xx_train)\n",
+    "save_np(\"../resources/csv/in/logsb_data_1.csv\", yy_train)\n",
+    "save_np(\"../resources/csv/in/logsb_grid_cov_mix_1.csv\", xx_test)\n",
+    "save_np(\"../resources/csv/in/logsb_grid_data_1.csv\", yy_test)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Run the executable:"
    ]
   },
   {
@@ -112,7 +129,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Run the executable\n",
     "cmd = ('../build/run ../algo_settings.asciipb '\n",
     "    'NNIG ../resources/asciipb/nnig_ngg_prior.asciipb '\n",
     "    'LogSB ../resources/asciipb/lsb_normal_prior.asciipb \"\" '\n",
@@ -132,13 +148,10 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "def sigmoid(x):\n",
-    "    return 1.0 / (1 + np.exp(-x))"
+    "Initialize parameters:"
    ]
   },
   {
@@ -169,13 +182,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "np.random.seed(20201124)\n",
     "n2 = 200\n",
-    "rng2 = 20201124\n",
-    "np.random.seed(rng2)\n",
     "# Covariates\n",
     "xx2 = np.random.multivariate_normal(mean=x_mean,\n",
-    "                                    cov=x_var2*np.identity(dim2),\n",
-    "                                    size=n2)\n",
+    "    cov=x_var2*np.identity(dim2), size=n2)\n",
     "# Data points\n",
     "yy2 = np.zeros(n2)\n",
     "for i in range(n2):\n",
@@ -196,14 +207,51 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Split into train and test sets:"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
+    "np.random.seed(20201124)\n",
+    "perc_test2 = 0.25\n",
+    "xx_train2, xx_test2, yy_train2, yy_test2 = train_test_split(xx2, yy2,\n",
+    "    test_size=perc_test2, shuffle=False)\n",
     "# Save to file\n",
-    "save_np(\"../resources/csv/in/logsb_cov_mix_2.csv\", xx2)\n",
-    "save_np(\"../resources/csv/in/logsb_data_2.csv\", yy2)"
+    "save_np(\"../resources/csv/in/logsb_cov_mix_2.csv\", xx_train2)\n",
+    "save_np(\"../resources/csv/in/logsb_data_2.csv\", yy_train2)\n",
+    "save_np(\"../resources/csv/in/logsb_grid_cov_mix_2.csv\", xx_test2)\n",
+    "save_np(\"../resources/csv/in/logsb_grid_data_2.csv\", yy_test2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Run the executable:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cmd = ('../build/run ../algo_settings.asciipb '\n",
+    "    'NNIG ../resources/asciipb/nnig_ngg_prior.asciipb '\n",
+    "    'LogSB ../resources/asciipb/lsb_normal_prior.asciipb \"\" '\n",
+    "    '../resources/csv/in/logsb_data_2.csv ../resources/csv/in/logsb_grid_data_2.csv '\n",
+    "    '../resources/csv/out/logsb_dens_2.csv ../resources/csv/out/logsb_nclu_2.csv '\n",
+    "    '../resources/csv/out/logsb_clus_2.csv \"\" \"\" '\n",
+    "    '../resources/csv/in/logsb_cov_mix_2.csv '\n",
+    "    '../resources/csv/in/logsb_grid_cov_mix_2.csv').split()\n",
+    "subprocess.run(cmd, capture_output=True)"
    ]
   },
   {

--- a/python/stickbreak.ipynb
+++ b/python/stickbreak.ipynb
@@ -99,10 +99,12 @@
     "n1 = 200\n",
     "np.random.seed(20201124)\n",
     "# Allocations\n",
-    "cc1 = []\n",
+    "cc1 = np.zeros(n1, dtype=int)\n",
+    "cur = 0\n",
     "for c in range(n_clus1):\n",
     "    nn = int(weights1[c] * n1)\n",
-    "    cc1.extend(nn * [c])\n",
+    "    cc1[cur:cur+nn] = c\n",
+    "    cur += nn\n",
     "# Covariates\n",
     "xx1 = np.zeros((n1, dim1))\n",
     "for i in range(n1):\n",
@@ -411,12 +413,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "true_clust1 = [cc1[i] for i in train_idxs1]\n",
-    "true_clust2 = [cc2[i] for i in train_idxs2]\n",
+    "true_clust1 = cc1[np.where(training_mask1)[0]]\n",
+    "true_clust2 = cc2[np.where(training_mask2)[0]]\n",
     "ari1 = adjusted_rand_score(clust1, true_clust1)\n",
     "ari2 = adjusted_rand_score(clust2, true_clust2)\n",
-    "print(ari1)\n",
-    "print(ari2)"
+    "print(\"ARI 1 =\", ari1)\n",
+    "print(\"ARI 2 =\", ari2)"
    ]
   },
   {

--- a/run.cc
+++ b/run.cc
@@ -103,7 +103,7 @@ int main(int argc, char *argv[]) {
   Eigen::MatrixXd clusterings(coll->get_size(), data.rows());
   Eigen::VectorXd num_clust(coll->get_size());
   for (int i = 0; i < coll->get_size(); i++) {
-    bayesmix::MarginalState state;
+    bayesmix::AlgorithmState state;
     coll->get_next_state(&state);
     for (int j = 0; j < data.rows(); j++) {
       clusterings(i, j) = state.cluster_allocs(j);

--- a/run.cc
+++ b/run.cc
@@ -18,20 +18,19 @@ int main(int argc, char *argv[]) {
   std::string datafile = argv[7];
   std::string gridfile = argv[8];
   std::string densfile = argv[9];
-  std::string massfile = argv[10];
-  std::string nclufile = argv[11];
-  std::string clusfile = argv[12];
+  std::string nclufile = argv[10];
+  std::string clusfile = argv[11];
   std::string hier_cov_file;
   std::string hier_grid_cov_file;
   std::string mix_cov_file;
   std::string mix_grid_cov_file;
-  if (argc >= 15) {
-    hier_cov_file = argv[13];
-    hier_grid_cov_file = argv[14];
+  if (argc >= 14) {
+    hier_cov_file = argv[12];
+    hier_grid_cov_file = argv[13];
   }
-  if (argc >= 17) {
-    mix_cov_file = argv[15];
-    mix_grid_cov_file = argv[16];
+  if (argc >= 16) {
+    mix_cov_file = argv[14];
+    mix_grid_cov_file = argv[15];
   }
 
   // Read algorithm settings proto
@@ -105,17 +104,10 @@ int main(int argc, char *argv[]) {
       clusterings(i, j) = state.cluster_allocs(j);
     }
     num_clust(i) = state.cluster_states_size();
-    bayesmix::MixingState mixstate = state.mixing_state();
-    if (mixstate.has_dp_state()) {
-      masses(i) = mixstate.dp_state().totalmass();
-    }
   }
   // Write collected data to files
-  bayesmix::write_matrix_to_file(masses, massfile);
-  std::cout << "Successfully wrote total masses to " << massfile << std::endl;
   bayesmix::write_matrix_to_file(num_clust, nclufile);
   std::cout << "Successfully wrote cluster sizes to " << nclufile << std::endl;
-
   // Compute cluster estimate
   std::cout << "Computing cluster estimate..." << std::endl;
   Eigen::VectorXd clust_est = bayesmix::cluster_estimate(clusterings);

--- a/run.cc
+++ b/run.cc
@@ -62,13 +62,9 @@ int main(int argc, char *argv[]) {
   Eigen::MatrixXd mix_cov_grid(0, 0);
   if (hier->is_dependent()) {
     hier_cov_grid = bayesmix::read_eigen_matrix(hier_grid_cov_file);
-  } else {
-    hier_cov_grid = Eigen::MatrixXd(grid.rows(), 0);
   }
   if (mixing->is_dependent()) {
     mix_cov_grid = bayesmix::read_eigen_matrix(mix_grid_cov_file);
-  } else {
-    mix_cov_grid = Eigen::MatrixXd(grid.rows(), 0);
   }
 
   // Set algorithm parameters

--- a/run.cc
+++ b/run.cc
@@ -58,8 +58,8 @@ int main(int argc, char *argv[]) {
   // Read data matrices
   Eigen::MatrixXd data = bayesmix::read_eigen_matrix(datafile);
   Eigen::MatrixXd grid = bayesmix::read_eigen_matrix(gridfile);
-  Eigen::MatrixXd hier_cov_grid(0, 0);
-  Eigen::MatrixXd mix_cov_grid(0, 0);
+  Eigen::MatrixXd hier_cov_grid(0, 1);
+  Eigen::MatrixXd mix_cov_grid(0, 1);
   if (hier->is_dependent()) {
     hier_cov_grid = bayesmix::read_eigen_matrix(hier_grid_cov_file);
   }

--- a/run.cc
+++ b/run.cc
@@ -58,8 +58,8 @@ int main(int argc, char *argv[]) {
   // Read data matrices
   Eigen::MatrixXd data = bayesmix::read_eigen_matrix(datafile);
   Eigen::MatrixXd grid = bayesmix::read_eigen_matrix(gridfile);
-  Eigen::MatrixXd hier_cov_grid(0, 1);
-  Eigen::MatrixXd mix_cov_grid(0, 1);
+  Eigen::MatrixXd hier_cov_grid = Eigen::VectorXd(0);
+  Eigen::MatrixXd mix_cov_grid = Eigen::VectorXd(0);
   if (hier->is_dependent()) {
     hier_cov_grid = bayesmix::read_eigen_matrix(hier_grid_cov_file);
   }

--- a/run.cc
+++ b/run.cc
@@ -58,8 +58,8 @@ int main(int argc, char *argv[]) {
   // Read data matrices
   Eigen::MatrixXd data = bayesmix::read_eigen_matrix(datafile);
   Eigen::MatrixXd grid = bayesmix::read_eigen_matrix(gridfile);
-  Eigen::MatrixXd hier_cov_grid = Eigen::VectorXd(0);
-  Eigen::MatrixXd mix_cov_grid = Eigen::VectorXd(0);
+  Eigen::MatrixXd hier_cov_grid = Eigen::RowVectorXd(0);
+  Eigen::MatrixXd mix_cov_grid = Eigen::RowVectorXd(0);
   if (hier->is_dependent()) {
     hier_cov_grid = bayesmix::read_eigen_matrix(hier_grid_cov_file);
   }

--- a/run.cc
+++ b/run.cc
@@ -94,7 +94,6 @@ int main(int argc, char *argv[]) {
   std::cout << "Successfully wrote density to " << densfile << std::endl;
 
   // Collect mixing and cluster states
-  Eigen::VectorXd masses(coll->get_size());
   Eigen::MatrixXd clusterings(coll->get_size(), data.rows());
   Eigen::VectorXd num_clust(coll->get_size());
   for (int i = 0; i < coll->get_size(); i++) {

--- a/src/algorithms/base_algorithm.cc
+++ b/src/algorithms/base_algorithm.cc
@@ -155,8 +155,8 @@ bool BaseAlgorithm::update_state_from_collector(BaseCollector *coll) {
 //! \return          Matrix whose i-th column is the lpdf at i-th iteration
 Eigen::MatrixXd BaseAlgorithm::eval_lpdf(
     BaseCollector *const collector, const Eigen::MatrixXd &grid,
-    const Eigen::MatrixXd &hier_covariates /*= Eigen::MatrixXd(0, 0)*/,
-    const Eigen::MatrixXd &mix_covariates /*= Eigen::MatrixXd(0, 0)*/) {
+    const Eigen::VectorXd &hier_covariate /*= Eigen::VectorXd(0)*/,
+    const Eigen::VectorXd &mix_covariate /*= Eigen::VectorXd(0)*/) {
   std::deque<Eigen::VectorXd> lpdf;
   bool keep = true;
   progresscpp::ProgressBar bar(collector->get_size(), 60);
@@ -165,7 +165,7 @@ Eigen::MatrixXd BaseAlgorithm::eval_lpdf(
     if (!keep) {
       break;
     }
-    lpdf.push_back(lpdf_from_state(grid, hier_covariates, mix_covariates));
+    lpdf.push_back(lpdf_from_state(grid, hier_covariate, mix_covariate));
     ++bar;
     bar.display();
   }

--- a/src/algorithms/base_algorithm.cc
+++ b/src/algorithms/base_algorithm.cc
@@ -69,30 +69,32 @@ void BaseAlgorithm::initialize() {
     mix_covariates = Eigen::MatrixXd::Zero(data.rows(), 0);
   }
   mixing->set_covariates(&mix_covariates);
+  // Initialize mixing
+  mixing->set_num_components(init_num_clusters);
+  mixing->initialize();
   // Interpet default number of clusters
-  if (init_num_clusters == 0) {
-    init_num_clusters = data.rows();
+  if (mixing->get_num_components() == 0) {
+    mixing->set_num_components(data.rows());
   }
   // Initialize hierarchies
   unique_values[0]->initialize();
-  for (size_t i = 0; i < init_num_clusters - 1; i++) {
+  unsigned int num_components = mixing->get_num_components();
+  for (size_t i = 0; i < num_components - 1; i++) {
     unique_values.push_back(unique_values[0]->clone());
     unique_values[i]->sample_prior();
   }
-  // Initialize mixing
-  mixing->initialize();
   // Build uniform probability on clusters, given their initial number
   std::default_random_engine generator;
-  std::uniform_int_distribution<int> distro(0, init_num_clusters - 1);
+  std::uniform_int_distribution<int> distro(0, num_components - 1);
   // Allocate one datum per cluster first, and update cardinalities
   allocations.clear();
-  for (size_t i = 0; i < init_num_clusters; i++) {
+  for (size_t i = 0; i < num_components; i++) {
     allocations.push_back(i);
     unique_values[i]->add_datum(i, data.row(i), update_hierarchy_params(),
                                 hier_covariates.row(i));
   }
   // Randomly allocate all remaining data, and update cardinalities
-  for (size_t i = init_num_clusters; i < data.rows(); i++) {
+  for (size_t i = num_components; i < data.rows(); i++) {
     unsigned int clust = distro(generator);
     allocations.push_back(clust);
     unique_values[clust]->add_datum(i, data.row(i), update_hierarchy_params(),

--- a/src/algorithms/base_algorithm.cc
+++ b/src/algorithms/base_algorithm.cc
@@ -155,8 +155,8 @@ bool BaseAlgorithm::update_state_from_collector(BaseCollector *coll) {
 //! \return          Matrix whose i-th column is the lpdf at i-th iteration
 Eigen::MatrixXd BaseAlgorithm::eval_lpdf(
     BaseCollector *const collector, const Eigen::MatrixXd &grid,
-    const Eigen::VectorXd &hier_covariate /*= Eigen::VectorXd(0)*/,
-    const Eigen::VectorXd &mix_covariate /*= Eigen::VectorXd(0)*/) {
+    const Eigen::RowVectorXd &hier_covariate /*= Eigen::VectorXd(0)*/,
+    const Eigen::RowVectorXd &mix_covariate /*= Eigen::VectorXd(0)*/) {
   std::deque<Eigen::VectorXd> lpdf;
   bool keep = true;
   progresscpp::ProgressBar bar(collector->get_size(), 60);

--- a/src/algorithms/base_algorithm.cc
+++ b/src/algorithms/base_algorithm.cc
@@ -155,8 +155,8 @@ bool BaseAlgorithm::update_state_from_collector(BaseCollector *coll) {
 //! \return          Matrix whose i-th column is the lpdf at i-th iteration
 Eigen::MatrixXd BaseAlgorithm::eval_lpdf(
     BaseCollector *const collector, const Eigen::MatrixXd &grid,
-    const Eigen::RowVectorXd &hier_covariate /*= Eigen::VectorXd(0)*/,
-    const Eigen::RowVectorXd &mix_covariate /*= Eigen::VectorXd(0)*/) {
+    const Eigen::RowVectorXd &hier_covariate /*= Eigen::RowVectorXd(0)*/,
+    const Eigen::RowVectorXd &mix_covariate /*= Eigen::RowVectorXd(0)*/) {
   std::deque<Eigen::VectorXd> lpdf;
   bool keep = true;
   progresscpp::ProgressBar bar(collector->get_size(), 60);

--- a/src/algorithms/base_algorithm.cc
+++ b/src/algorithms/base_algorithm.cc
@@ -5,7 +5,7 @@
 #include <vector>
 
 #include "algorithm_params.pb.h"
-#include "marginal_state.pb.h"
+#include "algorithm_state.pb.h"
 #include "mixing_state.pb.h"
 #include "src/algorithms/neal8_algorithm.h"
 #include "src/utils/rng.h"
@@ -94,8 +94,8 @@ void BaseAlgorithm::initialize() {
 }
 
 void BaseAlgorithm::update_hierarchy_hypers() {
-  bayesmix::MarginalState::ClusterState clust;
-  std::vector<bayesmix::MarginalState::ClusterState> states;
+  bayesmix::AlgorithmState::ClusterState clust;
+  std::vector<bayesmix::AlgorithmState::ClusterState> states;
   for (auto &un : unique_values) {
     if (un->get_card() > 0) {
       un->write_state_to_proto(&clust);
@@ -107,15 +107,15 @@ void BaseAlgorithm::update_hierarchy_hypers() {
 
 //! \param iter Number of the current iteration
 //! \return     Protobuf-object version of the current state
-bayesmix::MarginalState BaseAlgorithm::get_state_as_proto(unsigned int iter) {
-  bayesmix::MarginalState iter_out;
+bayesmix::AlgorithmState BaseAlgorithm::get_state_as_proto(unsigned int iter) {
+  bayesmix::AlgorithmState iter_out;
   // Transcribe iteration number, allocations, and cardinalities
   iter_out.set_iteration_num(iter);
   *iter_out.mutable_cluster_allocs() = {allocations.begin(),
                                         allocations.end()};
   // Transcribe unique values vector
   for (size_t i = 0; i < unique_values.size(); i++) {
-    bayesmix::MarginalState::ClusterState clusval;
+    bayesmix::AlgorithmState::ClusterState clusval;
     unique_values[i]->write_state_to_proto(&clusval);
     iter_out.add_cluster_states()->CopyFrom(clusval);
   }

--- a/src/algorithms/base_algorithm.cc
+++ b/src/algorithms/base_algorithm.cc
@@ -140,6 +140,11 @@ void BaseAlgorithm::read_params_from_proto(
   rng.seed(params.rng_seed());
 }
 
+bool BaseAlgorithm::update_state_from_collector(BaseCollector *coll) {
+  bool success = coll->get_next_state(&curr_state);
+  return success;
+}
+
 //! \param grid      Grid of points in matrix form to evaluate the density on
 //! \param collector Collector containing the algorithm chain
 //! \return          Matrix whose i-th column is the lpdf at i-th iteration

--- a/src/algorithms/base_algorithm.cc
+++ b/src/algorithms/base_algorithm.cc
@@ -52,7 +52,7 @@ void BaseAlgorithm::initialize() {
   }
   if (this->is_conditional() != mixing->is_conditional()) {
     throw std::invalid_argument(
-        "Algorithm and mixing must be either both"
+        "Algorithm and mixing must be either both "
         "marginal or both conditional");
   }
   if (mix_covariates.rows() != 0) {

--- a/src/algorithms/base_algorithm.cc
+++ b/src/algorithms/base_algorithm.cc
@@ -6,8 +6,11 @@
 
 #include "algorithm_params.pb.h"
 #include "algorithm_state.pb.h"
+#include "lib/progressbar/progressbar.h"
 #include "mixing_state.pb.h"
 #include "src/algorithms/neal8_algorithm.h"
+#include "src/collectors/base_collector.h"
+#include "src/utils/eigen_utils.h"
 #include "src/utils/rng.h"
 
 void BaseAlgorithm::initialize() {
@@ -135,4 +138,28 @@ void BaseAlgorithm::read_params_from_proto(
   init_num_clusters = params.init_num_clusters();
   auto &rng = bayesmix::Rng::Instance().get();
   rng.seed(params.rng_seed());
+}
+
+//! \param grid      Grid of points in matrix form to evaluate the density on
+//! \param collector Collector containing the algorithm chain
+//! \return          Matrix whose i-th column is the lpdf at i-th iteration
+Eigen::MatrixXd BaseAlgorithm::eval_lpdf(
+    BaseCollector *const collector, const Eigen::MatrixXd &grid,
+    const Eigen::MatrixXd &hier_covariates /*= Eigen::MatrixXd(0, 0)*/,
+    const Eigen::MatrixXd &mix_covariates /*= Eigen::MatrixXd(0, 0)*/) {
+  std::deque<Eigen::VectorXd> lpdf;
+  bool keep = true;
+  progresscpp::ProgressBar bar(collector->get_size(), 60);
+  while (keep) {
+    keep = update_state_from_collector(collector);
+    if (!keep) {
+      break;
+    }
+    lpdf.push_back(lpdf_from_state(grid, hier_covariates, mix_covariates));
+    ++bar;
+    bar.display();
+  }
+  collector->reset();
+  bar.done();
+  return bayesmix::stack_vectors(lpdf);
 }

--- a/src/algorithms/base_algorithm.cc
+++ b/src/algorithms/base_algorithm.cc
@@ -50,6 +50,11 @@ void BaseAlgorithm::initialize() {
   if (mixing == nullptr) {
     throw std::invalid_argument("Mixing was not provided to algorithm");
   }
+  if (this->is_conditional() != mixing->is_conditional()) {
+    throw std::invalid_argument(
+        "Algorithm and mixing must be either both"
+        "marginal or both conditional");
+  }
   if (mix_covariates.rows() != 0) {
     if (mixing->is_dependent() == false) {
       throw std::invalid_argument(

--- a/src/algorithms/base_algorithm.h
+++ b/src/algorithms/base_algorithm.h
@@ -112,6 +112,8 @@ class BaseAlgorithm {
  public:
   //!
   virtual bool requires_conjugate_hierarchy() const { return false; }
+  //!
+  virtual bool is_conditional() const = 0;
 
   //! Runs the algorithm and saves the whole chain to a collector
   void run(BaseCollector *collector) {

--- a/src/algorithms/base_algorithm.h
+++ b/src/algorithms/base_algorithm.h
@@ -139,13 +139,13 @@ class BaseAlgorithm {
 
   // ESTIMATE FUNCTION
   virtual Eigen::VectorXd lpdf_from_state(
-      const Eigen::MatrixXd &grid, const Eigen::MatrixXd &hier_covariates,
-      const Eigen::MatrixXd &mix_covariates) = 0;
+      const Eigen::MatrixXd &grid, const Eigen::VectorXd &hier_covariate,
+      const Eigen::VectorXd &mix_covariate) = 0;
   //! Evaluates the logpdf for each single iteration on a given grid of points
   virtual Eigen::MatrixXd eval_lpdf(
       BaseCollector *const collector, const Eigen::MatrixXd &grid,
-      const Eigen::MatrixXd &hier_covariates = Eigen::MatrixXd(0, 0),
-      const Eigen::MatrixXd &mix_covariates = Eigen::MatrixXd(0, 0));
+      const Eigen::VectorXd &hier_covariate = Eigen::VectorXd(0),
+      const Eigen::VectorXd &mix_covariate = Eigen::VectorXd(0));
 
   // DESTRUCTOR AND CONSTRUCTORS
   virtual ~BaseAlgorithm() = default;

--- a/src/algorithms/base_algorithm.h
+++ b/src/algorithms/base_algorithm.h
@@ -58,7 +58,7 @@ class BaseAlgorithm {
   // DATA AND VALUES CONTAINERS
   //! Matrix of row-vectorial data points
   Eigen::MatrixXd data;
-  //! Prescribed number of clusters for the algorithm initialization
+  //! Initial number of clusters, only used for initialization
   unsigned int init_num_clusters = 0;
   //! Allocation for each datum, i.e. label of the cluster it belongs to
   std::vector<unsigned int> allocations;
@@ -154,7 +154,6 @@ class BaseAlgorithm {
   // GETTERS AND SETTERS
   unsigned int get_maxiter() const { return maxiter; }
   unsigned int get_burnin() const { return burnin; }
-  unsigned int get_init_num_clusters() const { return init_num_clusters; }
 
   void set_maxiter(const unsigned int maxiter_) { maxiter = maxiter_; }
   void set_burnin(const unsigned int burnin_) { burnin = burnin_; }

--- a/src/algorithms/base_algorithm.h
+++ b/src/algorithms/base_algorithm.h
@@ -144,8 +144,8 @@ class BaseAlgorithm {
   //! Evaluates the logpdf for each single iteration on a given grid of points
   virtual Eigen::MatrixXd eval_lpdf(
       BaseCollector *const collector, const Eigen::MatrixXd &grid,
-      const Eigen::RowVectorXd &hier_covariate = Eigen::VectorXd(0),
-      const Eigen::RowVectorXd &mix_covariate = Eigen::VectorXd(0));
+      const Eigen::RowVectorXd &hier_covariate = Eigen::RowVectorXd(0),
+      const Eigen::RowVectorXd &mix_covariate = Eigen::RowVectorXd(0));
 
   // DESTRUCTOR AND CONSTRUCTORS
   virtual ~BaseAlgorithm() = default;

--- a/src/algorithms/base_algorithm.h
+++ b/src/algorithms/base_algorithm.h
@@ -131,7 +131,7 @@ class BaseAlgorithm {
   virtual Eigen::MatrixXd eval_lpdf(
       BaseCollector *const collector, const Eigen::MatrixXd &grid,
       const Eigen::MatrixXd &hier_covariates = Eigen::MatrixXd(0, 0),
-      const Eigen::MatrixXd &mix_covariates = Eigen::MatrixXd(0, 0)) = 0;
+      const Eigen::MatrixXd &mix_covariates = Eigen::MatrixXd(0, 0));
 
   // DESTRUCTOR AND CONSTRUCTORS
   virtual ~BaseAlgorithm() = default;

--- a/src/algorithms/base_algorithm.h
+++ b/src/algorithms/base_algorithm.h
@@ -139,13 +139,13 @@ class BaseAlgorithm {
 
   // ESTIMATE FUNCTION
   virtual Eigen::VectorXd lpdf_from_state(
-      const Eigen::MatrixXd &grid, const Eigen::VectorXd &hier_covariate,
-      const Eigen::VectorXd &mix_covariate) = 0;
+      const Eigen::MatrixXd &grid, const Eigen::RowVectorXd &hier_covariate,
+      const Eigen::RowVectorXd &mix_covariate) = 0;
   //! Evaluates the logpdf for each single iteration on a given grid of points
   virtual Eigen::MatrixXd eval_lpdf(
       BaseCollector *const collector, const Eigen::MatrixXd &grid,
-      const Eigen::VectorXd &hier_covariate = Eigen::VectorXd(0),
-      const Eigen::VectorXd &mix_covariate = Eigen::VectorXd(0));
+      const Eigen::RowVectorXd &hier_covariate = Eigen::VectorXd(0),
+      const Eigen::RowVectorXd &mix_covariate = Eigen::VectorXd(0));
 
   // DESTRUCTOR AND CONSTRUCTORS
   virtual ~BaseAlgorithm() = default;

--- a/src/algorithms/base_algorithm.h
+++ b/src/algorithms/base_algorithm.h
@@ -9,7 +9,7 @@
 
 #include "algorithm_id.pb.h"
 #include "algorithm_params.pb.h"
-#include "marginal_state.pb.h"
+#include "algorithm_state.pb.h"
 #include "src/collectors/base_collector.h"
 #include "src/hierarchies/base_hierarchy.h"
 #include "src/mixings/base_mixing.h"
@@ -75,7 +75,7 @@ class BaseAlgorithm {
 
   // AUXILIARY TOOLS
   //! Returns the values of an algo iteration as a Protobuf object
-  bayesmix::MarginalState get_state_as_proto(unsigned int iter);
+  bayesmix::AlgorithmState get_state_as_proto(unsigned int iter);
 
   // ALGORITHM FUNCTIONS
   virtual void print_startup_message() const = 0;

--- a/src/algorithms/base_algorithm.h
+++ b/src/algorithms/base_algorithm.h
@@ -71,18 +71,27 @@ class BaseAlgorithm {
   //!
   Eigen::MatrixXd mix_covariates;
   //!
+  bayesmix::AlgorithmState curr_state;
+  //!
   virtual bool update_hierarchy_params() { return false; }
 
   // AUXILIARY TOOLS
   //! Returns the values of an algo iteration as a Protobuf object
   bayesmix::AlgorithmState get_state_as_proto(unsigned int iter);
+  bool update_state_from_collector(BaseCollector *coll);
 
   // ALGORITHM FUNCTIONS
-  virtual void print_startup_message() const = 0;
+  //!
   virtual void initialize();
+  //!
+  virtual void print_startup_message() const = 0;
+  //!
   virtual void sample_allocations() = 0;
+  //!
   virtual void sample_unique_values() = 0;
+  //!
   void update_hierarchy_hypers();
+  //!
   virtual void print_ending_message() const {
     std::cout << "Done" << std::endl;
   };
@@ -127,6 +136,9 @@ class BaseAlgorithm {
   }
 
   // ESTIMATE FUNCTION
+  virtual Eigen::VectorXd lpdf_from_state(
+      const Eigen::MatrixXd &grid, const Eigen::MatrixXd &hier_covariates,
+      const Eigen::MatrixXd &mix_covariates) = 0;
   //! Evaluates the logpdf for each single iteration on a given grid of points
   virtual Eigen::MatrixXd eval_lpdf(
       BaseCollector *const collector, const Eigen::MatrixXd &grid,

--- a/src/algorithms/blocked_gibbs_algorithm.cc
+++ b/src/algorithms/blocked_gibbs_algorithm.cc
@@ -22,11 +22,12 @@ void BlockedGibbsAlgorithm::sample_allocations() {
   unsigned int num_components = 0;  // TODO; maybe we should set init_num_cl...
   for (int i = 0; i < data.rows(); i++) {
     // Compute weights
-    Eigen::VectorXd logprobas = cond_mixing->get_weights(
-      true, false, mix_covariates.row(i));;
+    Eigen::VectorXd logprobas =
+        cond_mixing->get_weights(true, false, mix_covariates.row(i));
+    ;
     for (int j = 0; j < num_components; j++) {
-      logprobas(j) = old_weights(j) + unique_values[j]->like_lpdf(
-                                          data.row(j), hier_covariates.row(j));
+      logprobas(j) +=
+          unique_values[j]->like_lpdf(data.row(j), hier_covariates.row(j));
     }
     // Draw a NEW value for datum allocation
     unsigned int c_new =
@@ -37,8 +38,8 @@ void BlockedGibbsAlgorithm::sample_allocations() {
       // Remove datum from old cluster, add to new
       unique_values[c_old]->remove_datum(
           i, data.row(i), update_hierarchy_params(), hier_covariates.row(i));
-      unique_values[c_new]->add_datum(i, data.row(i), update_hierarchy_params(),
-                                      hier_covariates.row(i));
+      unique_values[c_new]->add_datum(
+          i, data.row(i), update_hierarchy_params(), hier_covariates.row(i));
     }
   }
 }

--- a/src/algorithms/blocked_gibbs_algorithm.cc
+++ b/src/algorithms/blocked_gibbs_algorithm.cc
@@ -23,7 +23,7 @@ void BlockedGibbsAlgorithm::sample_allocations() {
     // Compute weights
     Eigen::VectorXd logprobas =
         cond_mixing->get_weights(true, false, mix_covariates.row(i));
-    for (int j = 0; j < logprobas.size(); j++) {  // TODO?
+    for (int j = 0; j < logprobas.size(); j++) {
       logprobas(j) +=
           unique_values[j]->like_lpdf(data.row(j), hier_covariates.row(j));
     }

--- a/src/algorithms/blocked_gibbs_algorithm.cc
+++ b/src/algorithms/blocked_gibbs_algorithm.cc
@@ -9,10 +9,6 @@
 #include "src/utils/distributions.h"
 #include "src/utils/rng.h"
 
-void BlockedGibbsAlgorithm::initialize() const {
-  return;  // TODO
-}
-
 void BlockedGibbsAlgorithm::print_startup_message() const {
   std::string msg = "Running BlockedGibbs algorithm with " +
                     bayesmix::HierarchyId_Name(unique_values[0]->get_id()) +
@@ -23,13 +19,11 @@ void BlockedGibbsAlgorithm::print_startup_message() const {
 
 void BlockedGibbsAlgorithm::sample_allocations() {
   auto &rng = bayesmix::Rng::Instance().get();
-  unsigned int num_components = 0;  // TODO; maybe we should set init_num_cl...
   for (int i = 0; i < data.rows(); i++) {
     // Compute weights
     Eigen::VectorXd logprobas =
         cond_mixing->get_weights(true, false, mix_covariates.row(i));
-    ;
-    for (int j = 0; j < num_components; j++) {
+    for (int j = 0; j < logprobas.size(); j++) {  // TODO?
       logprobas(j) +=
           unique_values[j]->like_lpdf(data.row(j), hier_covariates.row(j));
     }

--- a/src/algorithms/blocked_gibbs_algorithm.cc
+++ b/src/algorithms/blocked_gibbs_algorithm.cc
@@ -13,7 +13,8 @@ void BlockedGibbsAlgorithm::print_startup_message() const {
   std::string msg = "Running BlockedGibbs algorithm with " +
                     bayesmix::HierarchyId_Name(unique_values[0]->get_id()) +
                     " hierarchies, " +
-                    bayesmix::MixingId_Name(cond_mixing->get_id()) + " mixing...";
+                    bayesmix::MixingId_Name(cond_mixing->get_id()) +
+                    " mixing...";
   std::cout << msg << std::endl;
 }
 

--- a/src/algorithms/blocked_gibbs_algorithm.cc
+++ b/src/algorithms/blocked_gibbs_algorithm.cc
@@ -13,17 +13,18 @@ void BlockedGibbsAlgorithm::print_startup_message() const {
   std::string msg = "Running BlockedGibbs algorithm with " +
                     bayesmix::HierarchyId_Name(unique_values[0]->get_id()) +
                     " hierarchies, " +
-                    bayesmix::MixingId_Name(mixing->get_id()) + " mixing...";
+                    bayesmix::MixingId_Name(cond_mixing->get_id()) + " mixing...";
   std::cout << msg << std::endl;
 }
 
 void BlockedGibbsAlgorithm::sample_allocations() {
   auto &rng = bayesmix::Rng::Instance().get();
+  unsigned int num_components = cond_mixing->get_num_components();
   for (int i = 0; i < data.rows(); i++) {
     // Compute weights
     Eigen::VectorXd logprobas =
         cond_mixing->get_weights(true, false, mix_covariates.row(i));
-    for (int j = 0; j < logprobas.size(); j++) {
+    for (int j = 0; j < num_components; j++) {
       logprobas(j) +=
           unique_values[j]->like_lpdf(data.row(j), hier_covariates.row(j));
     }

--- a/src/algorithms/blocked_gibbs_algorithm.cc
+++ b/src/algorithms/blocked_gibbs_algorithm.cc
@@ -27,7 +27,7 @@ void BlockedGibbsAlgorithm::sample_allocations() {
         cond_mixing->get_weights(true, false, mix_covariates.row(i));
     for (int j = 0; j < num_components; j++) {
       logprobas(j) +=
-          unique_values[j]->like_lpdf(data.row(j), hier_covariates.row(j));
+          unique_values[j]->like_lpdf(data.row(i), hier_covariates.row(i));
     }
     // Draw a NEW value for datum allocation
     unsigned int c_new =

--- a/src/algorithms/blocked_gibbs_algorithm.cc
+++ b/src/algorithms/blocked_gibbs_algorithm.cc
@@ -9,6 +9,10 @@
 #include "src/utils/distributions.h"
 #include "src/utils/rng.h"
 
+void BlockedGibbsAlgorithm::initialize() const {
+  return;  // TODO
+}
+
 void BlockedGibbsAlgorithm::print_startup_message() const {
   std::string msg = "Running BlockedGibbs algorithm with " +
                     bayesmix::HierarchyId_Name(unique_values[0]->get_id()) +

--- a/src/algorithms/blocked_gibbs_algorithm.cc
+++ b/src/algorithms/blocked_gibbs_algorithm.cc
@@ -4,6 +4,7 @@
 #include "mixing_id.pb.h"
 #include "src/hierarchies/base_hierarchy.h"
 #include "src/mixings/base_mixing.h"
+#include "src/utils/rng.h"
 
 void BlockedGibbsAlgorithm::print_startup_message() const {
   std::string msg = "Running BlockedGibbs algorithm with " +
@@ -14,9 +15,36 @@ void BlockedGibbsAlgorithm::print_startup_message() const {
 }
 
 void BlockedGibbsAlgorithm::sample_allocations() {
-  return;  // TODO
+  auto &rng = bayesmix::Rng::Instance().get();
+  unsigned int num_components = 0;  // TODO; maybe we should set init_num_cl...
+  Eigen::VectorXd old_weights = cond_mixing->get_weights();
+  for (int i = 0; i < data.rows(); i++) {
+    // Compute weights
+    Eigen::VectorXd new_weights(num_components);
+    for (int j = 0; j < num_components; j++) {
+      new_weights(j) = old_weights(j) * std::exp(unique_values[j]->like_lpdf(
+        data.row(j), hier_covariates.row(j)));
+    }
+    // Draw a NEW value for datum allocation
+    unsigned int c_new = bayesmix::categorical_rng(new_weights, rng, 0);
+    unsigned int c_old = allocations[i];
+    allocations[i] = c_new;
+    // Remove datum from old cluster, add to new
+    unique_values[c_old]->remove_datum(
+        i, data.row(i), update_hierarchy_params(), hier_covariates.row(i));
+    unique_values[c_new]->add_datum(
+        i, data.row(i), update_hierarchy_params(), hier_covariates.row(i));
+  }
 }
 
 void BlockedGibbsAlgorithm::sample_unique_values() {
-  return;  // TODO
+  for (auto &un : unique_values) {
+    // TODO should we only do it for nonempty clusters? if so, also in Neal2+
+    un->sample_full_cond(!update_hierarchy_params());
+  }
+}
+
+void BlockedGibbsAlgorithm::sample_weights() {
+  cond_mixing->update_state(unique_values, allocations);
+  // TODO anything else?
 }

--- a/src/algorithms/blocked_gibbs_algorithm.h
+++ b/src/algorithms/blocked_gibbs_algorithm.h
@@ -7,8 +7,6 @@
 class BlockedGibbsAlgorithm : public ConditionalAlgorithm {
  protected:
   //!
-  bool update_hierarchy_params() override { return true; }  // TODO ?
-  //!
   void print_startup_message() const override;
   //!
   void sample_allocations() override;

--- a/src/algorithms/blocked_gibbs_algorithm.h
+++ b/src/algorithms/blocked_gibbs_algorithm.h
@@ -5,8 +5,11 @@
 #include "conditional_algorithm.h"
 
 class BlockedGibbsAlgorithm : public ConditionalAlgorithm {
+ protected:
   //!
   bool update_hierarchy_params() override { return true; }  // TODO ?
+  //!
+  void initialize() override;
   //!
   void print_startup_message() const override;
   //!

--- a/src/algorithms/blocked_gibbs_algorithm.h
+++ b/src/algorithms/blocked_gibbs_algorithm.h
@@ -13,6 +13,8 @@ class BlockedGibbsAlgorithm : public ConditionalAlgorithm {
   void sample_allocations() override;
   //!
   void sample_unique_values() override;
+  //!
+  void sample_weights() override;
 
  public:
   ~BlockedGibbsAlgorithm() = default;

--- a/src/algorithms/blocked_gibbs_algorithm.h
+++ b/src/algorithms/blocked_gibbs_algorithm.h
@@ -9,8 +9,6 @@ class BlockedGibbsAlgorithm : public ConditionalAlgorithm {
   //!
   bool update_hierarchy_params() override { return true; }  // TODO ?
   //!
-  void initialize() override;
-  //!
   void print_startup_message() const override;
   //!
   void sample_allocations() override;

--- a/src/algorithms/conditional_algorithm.cc
+++ b/src/algorithms/conditional_algorithm.cc
@@ -27,7 +27,8 @@ Eigen::VectorXd ConditionalAlgorithm::lpdf_from_state(
         cond_mixing->get_weights(true, false, mix_covariates.row(j));  // TODO
     temp_hier->set_state_from_proto(curr_state.cluster_states(j));
     lpdf_local.col(j) =
-        logweights(j) + temp_hier->like_lpdf_grid(grid, hier_covariates);
+        logweights(j) +
+        temp_hier->like_lpdf_grid(grid, hier_covariates).array();
   }
 
   for (size_t j = 0; j < grid.rows(); j++) {

--- a/src/algorithms/conditional_algorithm.cc
+++ b/src/algorithms/conditional_algorithm.cc
@@ -16,23 +16,29 @@ void ConditionalAlgorithm::initialize() {
 Eigen::VectorXd ConditionalAlgorithm::lpdf_from_state(
     const Eigen::MatrixXd &grid, const Eigen::MatrixXd &hier_covariates,
     const Eigen::MatrixXd &mix_covariates) {
-  Eigen::VectorXd lpdf(grid.rows());
+  // Read mixing state
   unsigned int n_data = curr_state.cluster_allocs_size();
   unsigned int n_clust = curr_state.cluster_states_size();
   cond_mixing->set_state_from_proto(curr_state.mixing_state());
+  // Initialize estimate containers
   Eigen::MatrixXd lpdf_local(grid.rows(), n_clust);
+  Eigen::VectorXd lpdf_final(grid.rows());
   auto temp_hier = unique_values[0]->clone();
-  for (size_t j = 0; j < n_clust; j++) {
+  // Loop over grid points
+  for (size_t i = 0; i < grid.rows(); i++) {
+    // Get mixing weights for the i-th grid point
     Eigen::VectorXd logweights =
-        cond_mixing->get_weights(true, false, mix_covariates.row(j));  // TODO
-    temp_hier->set_state_from_proto(curr_state.cluster_states(j));
-    lpdf_local.col(j) =
-        logweights(j) +
-        temp_hier->like_lpdf_grid(grid, hier_covariates).array();
+        cond_mixing->get_weights(true, false, mix_covariates.row(i));
+    // Loop over clusters
+    for (size_t j = 0; j < n_clust; j++) {
+      temp_hier->set_state_from_proto(curr_state.cluster_states(j));
+      // Get local, single-point estimate
+      lpdf_local(i, j) =
+          logweights(j) +
+          temp_hier->like_lpdf(grid.row(i), hier_covariates.row(i));
+    }
+    // Final estimate for i-th grid point
+    lpdf_final(i) = stan::math::log_sum_exp(lpdf_local.row(i));
   }
-
-  for (size_t j = 0; j < grid.rows(); j++) {
-    lpdf(j) = stan::math::log_sum_exp(lpdf_local.row(j));
-  }
-  return lpdf;
+  return lpdf_final;
 }

--- a/src/algorithms/conditional_algorithm.cc
+++ b/src/algorithms/conditional_algorithm.cc
@@ -13,9 +13,29 @@ void ConditionalAlgorithm::initialize() {
 
 //! \param grid Grid of points in matrix form to evaluate the density on
 //! \param coll Collector containing the algorithm chain
-Eigen::MatrixXd ConditionalAlgorithm::eval_lpdf(
-    BaseCollector *const collector, const Eigen::MatrixXd &grid,
-    const Eigen::MatrixXd &hier_covariates /*= Eigen::MatrixXd(0, 0)*/,
-    const Eigen::MatrixXd &mix_covariates /*= Eigen::MatrixXd(0, 0)*/) {
-  return Eigen::MatrixXd::Zero(1, 1);  // TODO
+Eigen::MatrixXd ConditionalAlgorithm::eval_lpdf() {
+  // TODO use the MargAlgo one?
+}
+
+Eigen::VectorXd MarginalAlgorithm::lpdf_from_state(
+    const Eigen::MatrixXd &grid, const Eigen::MatrixXd &hier_covariates,
+    const Eigen::MatrixXd &mix_covariates) {
+  Eigen::VectorXd lpdf(grid.rows());
+  unsigned int n_data = curr_state.cluster_allocs_size();
+  unsigned int n_clust = curr_state.cluster_states_size();
+  marg_mixing->set_state_from_proto(curr_state.mixing_state());
+  Eigen::MatrixXd lpdf_local(grid.rows(), n_clust);
+  auto temp_hier = unique_values[0]->clone();
+  Eigen::VectorXd weights = ???;  // TODO
+  for (size_t j = 0; j < n_clust; j++) {
+    temp_hier->set_state_from_proto(curr_state.cluster_states(j));
+    lpdf_local.col(j) = std::log(weights(j)) +  // TODO use log flag?
+        temp_hier->like_lpdf_grid(grid, hier_covariates).array();
+    // TODO add mixing covariate
+  }
+
+  for (size_t j = 0; j < grid.rows(); j++) {
+    lpdf(j) = stan::math::log_sum_exp(lpdf_local.row(j));
+  }
+  return lpdf;
 }

--- a/src/algorithms/conditional_algorithm.cc
+++ b/src/algorithms/conditional_algorithm.cc
@@ -14,8 +14,8 @@ void ConditionalAlgorithm::initialize() {
 }
 
 Eigen::VectorXd ConditionalAlgorithm::lpdf_from_state(
-    const Eigen::MatrixXd &grid, const Eigen::MatrixXd &hier_covariates,
-    const Eigen::MatrixXd &mix_covariates) {
+    const Eigen::MatrixXd &grid, const Eigen::VectorXd &hier_covariate,
+    const Eigen::VectorXd &mix_covariate) {
   // Read mixing state
   unsigned int n_data = curr_state.cluster_allocs_size();
   unsigned int n_clust = curr_state.cluster_states_size();
@@ -28,14 +28,13 @@ Eigen::VectorXd ConditionalAlgorithm::lpdf_from_state(
   for (size_t i = 0; i < grid.rows(); i++) {
     // Get mixing weights for the i-th grid point
     Eigen::VectorXd logweights =
-        cond_mixing->get_weights(true, false, mix_covariates.row(i));
+        cond_mixing->get_weights(true, false, mix_covariate);
     // Loop over clusters
     for (size_t j = 0; j < n_clust; j++) {
       temp_hier->set_state_from_proto(curr_state.cluster_states(j));
       // Get local, single-point estimate
       lpdf_local(i, j) =
-          logweights(j) +
-          temp_hier->like_lpdf(grid.row(i), hier_covariates.row(i));
+          logweights(j) + temp_hier->like_lpdf(grid.row(i), hier_covariate);
     }
     // Final estimate for i-th grid point
     lpdf_final(i) = stan::math::log_sum_exp(lpdf_local.row(i));

--- a/src/algorithms/conditional_algorithm.cc
+++ b/src/algorithms/conditional_algorithm.cc
@@ -22,13 +22,12 @@ Eigen::VectorXd ConditionalAlgorithm::lpdf_from_state(
   cond_mixing->set_state_from_proto(curr_state.mixing_state());
   Eigen::MatrixXd lpdf_local(grid.rows(), n_clust);
   auto temp_hier = unique_values[0]->clone();
-  Eigen::VectorXd weights;  // TODO
   for (size_t j = 0; j < n_clust; j++) {
+    Eigen::VectorXd logweights =
+        cond_mixing->get_weights(true, false, mix_covariates.row(j));  // TODO
     temp_hier->set_state_from_proto(curr_state.cluster_states(j));
     lpdf_local.col(j) =
-        std::log(weights(j)) +
-        temp_hier->like_lpdf_grid(grid, hier_covariates).array();
-    // TODO add mixing covariate
+        logweights(j) + temp_hier->like_lpdf_grid(grid, hier_covariates);
   }
 
   for (size_t j = 0; j < grid.rows(); j++) {

--- a/src/algorithms/conditional_algorithm.cc
+++ b/src/algorithms/conditional_algorithm.cc
@@ -14,8 +14,8 @@ void ConditionalAlgorithm::initialize() {
 }
 
 Eigen::VectorXd ConditionalAlgorithm::lpdf_from_state(
-    const Eigen::MatrixXd &grid, const Eigen::VectorXd &hier_covariate,
-    const Eigen::VectorXd &mix_covariate) {
+    const Eigen::MatrixXd &grid, const Eigen::RowVectorXd &hier_covariate,
+    const Eigen::RowVectorXd &mix_covariate) {
   // Read mixing state
   unsigned int n_data = curr_state.cluster_allocs_size();
   unsigned int n_clust = curr_state.cluster_states_size();

--- a/src/algorithms/conditional_algorithm.cc
+++ b/src/algorithms/conditional_algorithm.cc
@@ -13,23 +13,24 @@ void ConditionalAlgorithm::initialize() {
 
 //! \param grid Grid of points in matrix form to evaluate the density on
 //! \param coll Collector containing the algorithm chain
-Eigen::MatrixXd ConditionalAlgorithm::eval_lpdf() {
+Eigen::MatrixXd ConditionalAlgorithm::eval_lpdf(...) {
   // TODO use the MargAlgo one?
 }
 
-Eigen::VectorXd MarginalAlgorithm::lpdf_from_state(
+Eigen::VectorXd ConditionalAlgorithm::lpdf_from_state(
     const Eigen::MatrixXd &grid, const Eigen::MatrixXd &hier_covariates,
     const Eigen::MatrixXd &mix_covariates) {
   Eigen::VectorXd lpdf(grid.rows());
   unsigned int n_data = curr_state.cluster_allocs_size();
   unsigned int n_clust = curr_state.cluster_states_size();
-  marg_mixing->set_state_from_proto(curr_state.mixing_state());
+  cond_mixing->set_state_from_proto(curr_state.mixing_state());
   Eigen::MatrixXd lpdf_local(grid.rows(), n_clust);
   auto temp_hier = unique_values[0]->clone();
-  Eigen::VectorXd weights = ???;  // TODO
+  Eigen::VectorXd weights;  // TODO
   for (size_t j = 0; j < n_clust; j++) {
     temp_hier->set_state_from_proto(curr_state.cluster_states(j));
-    lpdf_local.col(j) = std::log(weights(j)) +  // TODO use log flag?
+    lpdf_local.col(j) =
+        std::log(weights(j)) +
         temp_hier->like_lpdf_grid(grid, hier_covariates).array();
     // TODO add mixing covariate
   }

--- a/src/algorithms/conditional_algorithm.cc
+++ b/src/algorithms/conditional_algorithm.cc
@@ -1,7 +1,9 @@
 #include "conditional_algorithm.h"
 
 #include <Eigen/Dense>
+#include <stan/math/prim/fun.hpp>
 
+#include "algorithm_state.pb.h"
 #include "base_algorithm.h"
 #include "src/collectors/base_collector.h"
 #include "src/mixings/conditional_mixing.h"
@@ -9,12 +11,6 @@
 void ConditionalAlgorithm::initialize() {
   BaseAlgorithm::initialize();
   cond_mixing = std::dynamic_pointer_cast<ConditionalMixing>(mixing);
-}
-
-//! \param grid Grid of points in matrix form to evaluate the density on
-//! \param coll Collector containing the algorithm chain
-Eigen::MatrixXd ConditionalAlgorithm::eval_lpdf(...) {
-  // TODO use the MargAlgo one?
 }
 
 Eigen::VectorXd ConditionalAlgorithm::lpdf_from_state(

--- a/src/algorithms/conditional_algorithm.h
+++ b/src/algorithms/conditional_algorithm.h
@@ -14,8 +14,8 @@ class ConditionalAlgorithm : public BaseAlgorithm {
   std::shared_ptr<ConditionalMixing> cond_mixing;
   //!
   Eigen::VectorXd lpdf_from_state(
-      const Eigen::MatrixXd &grid, const Eigen::VectorXd &hier_covariate,
-      const Eigen::VectorXd &mix_covariate) override;
+      const Eigen::MatrixXd &grid, const Eigen::RowVectorXd &hier_covariate,
+      const Eigen::RowVectorXd &mix_covariate) override;
   //!
   void initialize() override;
   //!

--- a/src/algorithms/conditional_algorithm.h
+++ b/src/algorithms/conditional_algorithm.h
@@ -12,12 +12,15 @@ class ConditionalAlgorithm : public BaseAlgorithm {
  protected:
   //! Points at the same object as BaseAlgorithm::mixing
   std::shared_ptr<ConditionalMixing> cond_mixing;
-
- public:
-  ~ConditionalAlgorithm() = default;
-  ConditionalAlgorithm() = default;
+  //!
+  bayesmix::AlgorithmState curr_state;
+  //!
+  Eigen::VectorXd lpdf_from_state(const Eigen::MatrixXd &grid,
+                                  const Eigen::MatrixXd &hier_covariates,
+                                  const Eigen::MatrixXd &mix_covariates);
   //!
   void initialize() override;
+  //!
   virtual void sample_weights() = 0;
   //!
   void step() override {
@@ -26,11 +29,10 @@ class ConditionalAlgorithm : public BaseAlgorithm {
     update_hierarchy_hypers();
     sample_weights();
   }
-  //!
-  Eigen::MatrixXd eval_lpdf(
-      BaseCollector *const collector, const Eigen::MatrixXd &grid,
-      const Eigen::MatrixXd &hier_covariates = Eigen::MatrixXd(0, 0),
-      const Eigen::MatrixXd &mix_covariates = Eigen::MatrixXd(0, 0)) override;
+
+ public:
+  ~ConditionalAlgorithm() = default;
+  ConditionalAlgorithm() = default;
 };
 
 #endif  // BAYESMIX_ALGORITHMS_CONDITIONAL_ALGORITHM_H_

--- a/src/algorithms/conditional_algorithm.h
+++ b/src/algorithms/conditional_algorithm.h
@@ -18,10 +18,13 @@ class ConditionalAlgorithm : public BaseAlgorithm {
   ConditionalAlgorithm() = default;
   //!
   void initialize() override;
+  virtual void sample_weights() = 0;
   //!
   void step() override {
-    BaseAlgorithm::step();
-    cond_mixing->update_state(unique_values, allocations);
+    sample_allocations();
+    sample_unique_values();
+    update_hierarchy_hypers();
+    sample_weights();
   }
   //!
   Eigen::MatrixXd eval_lpdf(

--- a/src/algorithms/conditional_algorithm.h
+++ b/src/algorithms/conditional_algorithm.h
@@ -13,11 +13,9 @@ class ConditionalAlgorithm : public BaseAlgorithm {
   //! Points at the same object as BaseAlgorithm::mixing
   std::shared_ptr<ConditionalMixing> cond_mixing;
   //!
-  bayesmix::AlgorithmState curr_state;
-  //!
-  Eigen::VectorXd lpdf_from_state(const Eigen::MatrixXd &grid,
-                                  const Eigen::MatrixXd &hier_covariates,
-                                  const Eigen::MatrixXd &mix_covariates);
+  Eigen::VectorXd lpdf_from_state(
+      const Eigen::MatrixXd &grid, const Eigen::MatrixXd &hier_covariates,
+      const Eigen::MatrixXd &mix_covariates) override;
   //!
   void initialize() override;
   //!

--- a/src/algorithms/conditional_algorithm.h
+++ b/src/algorithms/conditional_algorithm.h
@@ -31,6 +31,8 @@ class ConditionalAlgorithm : public BaseAlgorithm {
  public:
   ~ConditionalAlgorithm() = default;
   ConditionalAlgorithm() = default;
+  //!
+  bool is_conditional() const override { return true; }
 };
 
 #endif  // BAYESMIX_ALGORITHMS_CONDITIONAL_ALGORITHM_H_

--- a/src/algorithms/conditional_algorithm.h
+++ b/src/algorithms/conditional_algorithm.h
@@ -14,8 +14,8 @@ class ConditionalAlgorithm : public BaseAlgorithm {
   std::shared_ptr<ConditionalMixing> cond_mixing;
   //!
   Eigen::VectorXd lpdf_from_state(
-      const Eigen::MatrixXd &grid, const Eigen::MatrixXd &hier_covariates,
-      const Eigen::MatrixXd &mix_covariates) override;
+      const Eigen::MatrixXd &grid, const Eigen::VectorXd &hier_covariate,
+      const Eigen::VectorXd &mix_covariate) override;
   //!
   void initialize() override;
   //!

--- a/src/algorithms/marginal_algorithm.cc
+++ b/src/algorithms/marginal_algorithm.cc
@@ -14,8 +14,8 @@ void MarginalAlgorithm::initialize() {
 }
 
 Eigen::VectorXd MarginalAlgorithm::lpdf_from_state(
-    const Eigen::MatrixXd &grid, const Eigen::VectorXd &hier_covariate,
-    const Eigen::VectorXd &mix_covariate) {
+    const Eigen::MatrixXd &grid, const Eigen::RowVectorXd &hier_covariate,
+    const Eigen::RowVectorXd &mix_covariate) {
   // Read mixing state
   unsigned int n_data = curr_state.cluster_allocs_size();
   unsigned int n_clust = curr_state.cluster_states_size();

--- a/src/algorithms/marginal_algorithm.cc
+++ b/src/algorithms/marginal_algorithm.cc
@@ -3,8 +3,8 @@
 #include <Eigen/Dense>
 #include <stan/math/prim/fun.hpp>
 
+#include "algorithm_state.pb.h"
 #include "lib/progressbar/progressbar.h"
-#include "marginal_state.pb.h"
 #include "src/algorithms/base_algorithm.h"
 #include "src/collectors/base_collector.h"
 #include "src/mixings/marginal_mixing.h"

--- a/src/algorithms/marginal_algorithm.cc
+++ b/src/algorithms/marginal_algorithm.cc
@@ -26,18 +26,19 @@ Eigen::VectorXd MarginalAlgorithm::lpdf_from_state(
   auto temp_hier = unique_values[0]->clone();
   // Loop over grid points
   for (size_t i = 0; i < grid.rows(); i++) {
-    // Get mass values for i-th grid point
-    double mass_ex = marg_mixing->mass_existing_cluster(
-        n_data, true, false, temp_hier, mix_covariate);
-    double mass_new = marg_mixing->mass_new_cluster(n_data, true, false,
-                                                    n_clust, mix_covariate);
     // Loop over clusters
     for (size_t j = 0; j < n_clust; j++) {
+      // Get hierarchy and mass values
       temp_hier->set_state_from_proto(curr_state.cluster_states(j));
+      double mass_ex = marg_mixing->mass_existing_cluster(
+          n_data, true, false, temp_hier, mix_covariate);
       // Get local, single-point estimate
       lpdf_local(i, j) =
           mass_ex + temp_hier->like_lpdf(grid.row(i), hier_covariate);
     }
+    // Marginal component of estimate
+    double mass_new = marg_mixing->mass_new_cluster(n_data, true, false,
+                                                    n_clust, mix_covariate);
     lpdf_local(i, n_clust) =
         mass_new +
         lpdf_marginal_component(temp_hier, grid.row(i), hier_covariate)(0);

--- a/src/algorithms/marginal_algorithm.cc
+++ b/src/algorithms/marginal_algorithm.cc
@@ -4,39 +4,13 @@
 #include <stan/math/prim/fun.hpp>
 
 #include "algorithm_state.pb.h"
-#include "lib/progressbar/progressbar.h"
 #include "src/algorithms/base_algorithm.h"
 #include "src/collectors/base_collector.h"
 #include "src/mixings/marginal_mixing.h"
-#include "src/utils/eigen_utils.h"
 
 void MarginalAlgorithm::initialize() {
   BaseAlgorithm::initialize();
   marg_mixing = std::dynamic_pointer_cast<MarginalMixing>(mixing);
-}
-
-//! \param grid      Grid of points in matrix form to evaluate the density on
-//! \param collector Collector containing the algorithm chain
-//! \return          Matrix whose i-th column is the lpdf at i-th iteration
-Eigen::MatrixXd MarginalAlgorithm::eval_lpdf(
-    BaseCollector *const collector, const Eigen::MatrixXd &grid,
-    const Eigen::MatrixXd &hier_covariates /*= Eigen::MatrixXd(0, 0)*/,
-    const Eigen::MatrixXd &mix_covariates /*= Eigen::MatrixXd(0, 0)*/) {
-  std::deque<Eigen::VectorXd> lpdf;
-  bool keep = true;
-  progresscpp::ProgressBar bar(collector->get_size(), 60);
-  while (keep) {
-    keep = update_state_from_collector(collector);
-    if (!keep) {
-      break;
-    }
-    lpdf.push_back(lpdf_from_state(grid, hier_covariates, mix_covariates));
-    ++bar;
-    bar.display();
-  }
-  collector->reset();
-  bar.done();
-  return bayesmix::stack_vectors(lpdf);
 }
 
 Eigen::VectorXd MarginalAlgorithm::lpdf_from_state(

--- a/src/algorithms/marginal_algorithm.cc
+++ b/src/algorithms/marginal_algorithm.cc
@@ -4,7 +4,7 @@
 #include <stan/math/prim/fun.hpp>
 
 #include "algorithm_state.pb.h"
-#include "src/algorithms/base_algorithm.h"
+#include "base_algorithm.h"
 #include "src/collectors/base_collector.h"
 #include "src/mixings/marginal_mixing.h"
 
@@ -38,9 +38,4 @@ Eigen::VectorXd MarginalAlgorithm::lpdf_from_state(
     lpdf(j) = stan::math::log_sum_exp(lpdf_local.row(j));
   }
   return lpdf;
-}
-
-bool MarginalAlgorithm::update_state_from_collector(BaseCollector *coll) {
-  bool success = coll->get_next_state(&curr_state);
-  return success;
 }

--- a/src/algorithms/marginal_algorithm.h
+++ b/src/algorithms/marginal_algorithm.h
@@ -6,8 +6,8 @@
 #include <Eigen/Dense>
 #include <memory>
 
+#include "algorithm_state.pb.h"
 #include "base_algorithm.h"
-#include "marginal_state.pb.h"
 #include "src/collectors/base_collector.h"
 #include "src/hierarchies/base_hierarchy.h"
 #include "src/mixings/marginal_mixing.h"
@@ -17,7 +17,7 @@ class MarginalAlgorithm : public BaseAlgorithm {
   //! Points at the same object as BaseAlgorithm::mixing
   std::shared_ptr<MarginalMixing> marg_mixing;
   //!
-  bayesmix::MarginalState curr_state;
+  bayesmix::AlgorithmState curr_state;
   //!
   void initialize() override;
   //! Computes marginal contribution of a given iteration & cluster

--- a/src/algorithms/marginal_algorithm.h
+++ b/src/algorithms/marginal_algorithm.h
@@ -19,8 +19,8 @@ class MarginalAlgorithm : public BaseAlgorithm {
       const Eigen::MatrixXd &covariates) const = 0;
   //!
   Eigen::VectorXd lpdf_from_state(
-      const Eigen::MatrixXd &grid, const Eigen::VectorXd &hier_covariate,
-      const Eigen::VectorXd &mix_covariate) override;
+      const Eigen::MatrixXd &grid, const Eigen::RowVectorXd &hier_covariate,
+      const Eigen::RowVectorXd &mix_covariate) override;
   //!
   void initialize() override;
 

--- a/src/algorithms/marginal_algorithm.h
+++ b/src/algorithms/marginal_algorithm.h
@@ -27,6 +27,8 @@ class MarginalAlgorithm : public BaseAlgorithm {
  public:
   ~MarginalAlgorithm() = default;
   MarginalAlgorithm() = default;
+  //!
+  bool is_conditional() const override { return false; }
 };
 
 #endif  // BAYESMIX_ALGORITHMS_MARGINAL_ALGORITHM_H_

--- a/src/algorithms/marginal_algorithm.h
+++ b/src/algorithms/marginal_algorithm.h
@@ -19,8 +19,8 @@ class MarginalAlgorithm : public BaseAlgorithm {
       const Eigen::MatrixXd &covariates) const = 0;
   //!
   Eigen::VectorXd lpdf_from_state(
-      const Eigen::MatrixXd &grid, const Eigen::MatrixXd &hier_covariates,
-      const Eigen::MatrixXd &mix_covariates) override;
+      const Eigen::MatrixXd &grid, const Eigen::VectorXd &hier_covariate,
+      const Eigen::VectorXd &mix_covariate) override;
   //!
   void initialize() override;
 

--- a/src/algorithms/marginal_algorithm.h
+++ b/src/algorithms/marginal_algorithm.h
@@ -1,12 +1,9 @@
 #ifndef BAYESMIX_ALGORITHMS_MARGINAL_ALGORITHM_H_
 #define BAYESMIX_ALGORITHMS_MARGINAL_ALGORITHM_H_
 
-#include <google/protobuf/message.h>
-
 #include <Eigen/Dense>
 #include <memory>
 
-#include "algorithm_state.pb.h"
 #include "base_algorithm.h"
 #include "src/collectors/base_collector.h"
 #include "src/hierarchies/abstract_hierarchy.h"
@@ -16,29 +13,20 @@ class MarginalAlgorithm : public BaseAlgorithm {
  protected:
   //! Points at the same object as BaseAlgorithm::mixing
   std::shared_ptr<MarginalMixing> marg_mixing;
-  //!
-  bayesmix::AlgorithmState curr_state;
   //! Computes marginal contribution of a given iteration & cluster
   virtual Eigen::VectorXd lpdf_marginal_component(
       std::shared_ptr<AbstractHierarchy> hier, const Eigen::MatrixXd &grid,
       const Eigen::MatrixXd &covariates) const = 0;
   //!
-  Eigen::VectorXd lpdf_from_state(const Eigen::MatrixXd &grid,
-                                  const Eigen::MatrixXd &hier_covariates,
-                                  const Eigen::MatrixXd &mix_covariates);
-  //!
-  bool update_state_from_collector(BaseCollector *coll);
+  Eigen::VectorXd lpdf_from_state(
+      const Eigen::MatrixXd &grid, const Eigen::MatrixXd &hier_covariates,
+      const Eigen::MatrixXd &mix_covariates) override;
   //!
   void initialize() override;
 
  public:
   ~MarginalAlgorithm() = default;
   MarginalAlgorithm() = default;
-  //!
-  Eigen::MatrixXd eval_lpdf(
-      BaseCollector *const collector, const Eigen::MatrixXd &grid,
-      const Eigen::MatrixXd &hier_covariates = Eigen::MatrixXd(0, 0),
-      const Eigen::MatrixXd &mix_covariates = Eigen::MatrixXd(0, 0)) override;
 };
 
 #endif  // BAYESMIX_ALGORITHMS_MARGINAL_ALGORITHM_H_

--- a/src/algorithms/marginal_algorithm.h
+++ b/src/algorithms/marginal_algorithm.h
@@ -9,7 +9,7 @@
 #include "algorithm_state.pb.h"
 #include "base_algorithm.h"
 #include "src/collectors/base_collector.h"
-#include "src/hierarchies/base_hierarchy.h"
+#include "src/hierarchies/abstract_hierarchy.h"
 #include "src/mixings/marginal_mixing.h"
 
 class MarginalAlgorithm : public BaseAlgorithm {
@@ -18,8 +18,6 @@ class MarginalAlgorithm : public BaseAlgorithm {
   std::shared_ptr<MarginalMixing> marg_mixing;
   //!
   bayesmix::AlgorithmState curr_state;
-  //!
-  void initialize() override;
   //! Computes marginal contribution of a given iteration & cluster
   virtual Eigen::VectorXd lpdf_marginal_component(
       std::shared_ptr<AbstractHierarchy> hier, const Eigen::MatrixXd &grid,
@@ -30,6 +28,8 @@ class MarginalAlgorithm : public BaseAlgorithm {
                                   const Eigen::MatrixXd &mix_covariates);
   //!
   bool update_state_from_collector(BaseCollector *coll);
+  //!
+  void initialize() override;
 
  public:
   ~MarginalAlgorithm() = default;

--- a/src/algorithms/neal2_algorithm.cc
+++ b/src/algorithms/neal2_algorithm.cc
@@ -6,8 +6,8 @@
 #include <vector>
 
 #include "algorithm_id.pb.h"
+#include "algorithm_state.pb.h"
 #include "hierarchy_id.pb.h"
-#include "marginal_state.pb.h"
 #include "mixing_id.pb.h"
 #include "src/hierarchies/base_hierarchy.h"
 #include "src/mixings/marginal_mixing.h"

--- a/src/algorithms/neal2_algorithm.h
+++ b/src/algorithms/neal2_algorithm.h
@@ -41,17 +41,20 @@ class Neal2Algorithm : public MarginalAlgorithm {
   virtual Eigen::VectorXd get_cluster_lpdf(const unsigned int data_idx) const;
 
   // ALGORITHM FUNCTIONS
+  //!
   void print_startup_message() const override;
+  //!
   void sample_allocations() override;
+  //!
   void sample_unique_values() override;
 
  public:
   // DESTRUCTOR AND CONSTRUCTORS
   ~Neal2Algorithm() = default;
   Neal2Algorithm() = default;
-
+  //!
   bool requires_conjugate_hierarchy() const override { return true; }
-
+  //!
   bayesmix::AlgorithmId get_id() const override {
     return bayesmix::AlgorithmId::Neal2;
   }

--- a/src/algorithms/neal3_algorithm.h
+++ b/src/algorithms/neal3_algorithm.h
@@ -19,7 +19,7 @@ class Neal3Algorithm : public Neal2Algorithm {
   // DESTRUCTOR AND CONSTRUCTORS
   ~Neal3Algorithm() = default;
   Neal3Algorithm() = default;
-
+  //!
   bayesmix::AlgorithmId get_id() const override {
     return bayesmix::AlgorithmId::Neal3;
   }

--- a/src/algorithms/neal8_algorithm.cc
+++ b/src/algorithms/neal8_algorithm.cc
@@ -5,8 +5,8 @@
 #include <stan/math/prim/fun.hpp>
 
 #include "algorithm_id.pb.h"
+#include "algorithm_state.pb.h"
 #include "hierarchy_id.pb.h"
-#include "marginal_state.pb.h"
 #include "mixing_id.pb.h"
 #include "neal2_algorithm.h"
 #include "src/algorithms/marginal_algorithm.h"
@@ -101,7 +101,7 @@ void Neal8Algorithm::sample_allocations() {
     bool singleton = (unique_values[allocations[i]]->get_card() <= 1);
     if (singleton) {
       // Save unique value in the first auxiliary block
-      bayesmix::MarginalState::ClusterState curr_val;
+      bayesmix::AlgorithmState::ClusterState curr_val;
       unique_values[allocations[i]]->write_state_to_proto(&curr_val);
       aux_unique_values[0]->set_state_from_proto(curr_val);
     }

--- a/src/algorithms/neal8_algorithm.cc
+++ b/src/algorithms/neal8_algorithm.cc
@@ -71,6 +71,15 @@ Eigen::VectorXd Neal8Algorithm::get_cluster_lpdf(
   return loglpdf;
 }
 
+void Neal8Algorithm::initialize() {
+  MarginalAlgorithm::initialize();
+  // Create correct amount of auxiliary blocks
+  aux_unique_values.clear();
+  for (size_t i = 0; i < n_aux; i++) {
+    aux_unique_values.push_back(unique_values[0]->clone());
+  }
+}
+
 void Neal8Algorithm::print_startup_message() const {
   std::string msg = "Running Neal8 algorithm (m=" + std::to_string(n_aux) +
                     " aux. blocks) with " +
@@ -79,15 +88,6 @@ void Neal8Algorithm::print_startup_message() const {
                     bayesmix::MixingId_Name(marg_mixing->get_id()) +
                     " mixing...";
   std::cout << msg << std::endl;
-}
-
-void Neal8Algorithm::initialize() {
-  MarginalAlgorithm::initialize();
-  // Create correct amount of auxiliary blocks
-  aux_unique_values.clear();
-  for (size_t i = 0; i < n_aux; i++) {
-    aux_unique_values.push_back(unique_values[0]->clone());
-  }
 }
 
 void Neal8Algorithm::sample_allocations() {

--- a/src/algorithms/neal8_algorithm.h
+++ b/src/algorithms/neal8_algorithm.h
@@ -41,8 +41,8 @@ class Neal8Algorithm : public Neal2Algorithm {
   Eigen::VectorXd get_cluster_lpdf(const unsigned int data_idx) const override;
 
   // ALGORITHM FUNCTIONS
-  void print_startup_message() const override;
   void initialize() override;
+  void print_startup_message() const override;
   void sample_allocations() override;
 
  public:

--- a/src/algorithms/semihdp_sampler.cc
+++ b/src/algorithms/semihdp_sampler.cc
@@ -3,7 +3,7 @@
 #include <algorithm>
 #include <vector>
 
-#include "marginal_state.pb.h"
+#include "algorithm_state.pb.h"
 #include "src/utils/distributions.h"
 #include "src/utils/eigen_utils.h"
 
@@ -470,7 +470,7 @@ void SemiHdpSampler::sample_pseudo_prior() {
       Eigen::VectorXd::Ones(pseudo_iter).array() / (1.0 * pseudo_iter);
   int iter = bayesmix::categorical_rng(probas, rng);
   for (int r = 0; r < ngroups; r++) {
-    bayesmix::MarginalState state;
+    bayesmix::AlgorithmState state;
     pseudoprior_collectors[r].get_state(iter, &state);
     // compute the cardinalities
     int nclus = state.cluster_states_size();
@@ -492,7 +492,7 @@ void SemiHdpSampler::sample_pseudo_prior() {
 
     rest_tables_pseudo[r].resize(0);
     for (int l = 0; l < state.cluster_states_size(); l++) {
-      bayesmix::MarginalState::ClusterState clusval = state.cluster_states(l);
+      bayesmix::AlgorithmState::ClusterState clusval = state.cluster_states(l);
       // perturb(&clusval);
       std::shared_ptr<AbstractHierarchy> curr_clus =
           G0_master_hierarchy->clone();
@@ -502,7 +502,7 @@ void SemiHdpSampler::sample_pseudo_prior() {
   }
 }
 
-void SemiHdpSampler::perturb(bayesmix::MarginalState::ClusterState* out) {
+void SemiHdpSampler::perturb(bayesmix::AlgorithmState::ClusterState* out) {
   auto& rng = bayesmix::Rng::Instance().get();
   if (out->has_uni_ls_state()) {
     double cnt_shared_tables =
@@ -587,11 +587,11 @@ void SemiHdpSampler::reassign_group(int i, int new_r, int old_r) {
 }
 
 Eigen::VectorXd SemiHdpSampler::_compute_mixture_distance(int i) {
-  std::vector<bayesmix::MarginalState::ClusterState> clus1(
+  std::vector<bayesmix::AlgorithmState::ClusterState> clus1(
       rest_tables[i].size());
   Eigen::VectorXd weights1(rest_tables[i].size());
   for (int l = 0; l < rest_tables[i].size(); l++) {
-    bayesmix::MarginalState::ClusterState clus;
+    bayesmix::AlgorithmState::ClusterState clus;
     rest_tables[i][l]->write_state_to_proto(&clus);
     clus1[l] = clus;
     weights1(l) = n_by_table[i][l];
@@ -600,11 +600,11 @@ Eigen::VectorXd SemiHdpSampler::_compute_mixture_distance(int i) {
   Eigen::VectorXd dists(ngroups);
 
   for (int r = 0; r < ngroups; r++) {
-    std::vector<bayesmix::MarginalState::ClusterState> clus2(
+    std::vector<bayesmix::AlgorithmState::ClusterState> clus2(
         rest_tables[r].size());
     Eigen::VectorXd weights2(rest_tables[r].size());
     for (int l = 0; l < rest_tables[r].size(); l++) {
-      bayesmix::MarginalState::ClusterState clus;
+      bayesmix::AlgorithmState::ClusterState clus;
       rest_tables[r][l]->write_state_to_proto(&clus);
       clus2[l] = clus;
       weights2(l) = n_by_table[r][l];

--- a/src/algorithms/semihdp_sampler.h
+++ b/src/algorithms/semihdp_sampler.h
@@ -15,7 +15,7 @@
 #include "src/utils/distributions.h"
 #include "src/utils/rng.h"
 
-using bayesmix::MarginalState;
+using bayesmix::AlgorithmState;
 using bayesmix::SemiHdpState;
 
 /*
@@ -153,7 +153,7 @@ class SemiHdpSampler {
 
   void relabel();
   void sample_pseudo_prior();
-  void perturb(bayesmix::MarginalState::ClusterState *out);
+  void perturb(bayesmix::AlgorithmState::ClusterState *out);
 
   double lpdf_for_group(int i, int r);
   void reassign_group(int i, int new_r, int old_r);

--- a/src/collectors/base_collector.h
+++ b/src/collectors/base_collector.h
@@ -11,7 +11,7 @@
 #include <string>
 #include <vector>
 
-#include "marginal_state.pb.h"
+#include "algorithm_state.pb.h"
 
 //! Abstract base class for a collector that contains a chain in Protobuf form
 

--- a/src/hierarchies/abstract_hierarchy.h
+++ b/src/hierarchies/abstract_hierarchy.h
@@ -9,8 +9,8 @@
 #include <set>
 #include <stan/math/prim.hpp>
 
+#include "algorithm_state.pb.h"
 #include "hierarchy_id.pb.h"
-#include "marginal_state.pb.h"
 #include "src/utils/rng.h"
 
 //! Abstract base template class for a hierarchy object.
@@ -54,7 +54,7 @@ class AbstractHierarchy {
 
   //!
   virtual void update_hypers(
-      const std::vector<bayesmix::MarginalState::ClusterState> &states) = 0;
+      const std::vector<bayesmix::AlgorithmState::ClusterState> &states) = 0;
 
   // EVALUATION FUNCTIONS FOR SINGLE POINTS
   //! Evaluates the log-likelihood of data in a single point

--- a/src/hierarchies/abstract_hierarchy.h
+++ b/src/hierarchies/abstract_hierarchy.h
@@ -37,14 +37,14 @@ class AbstractHierarchy {
 
   //! Adds a datum and its index to the hierarchy
   virtual void add_datum(
-      const int id, const Eigen::VectorXd &datum,
+      const int id, const Eigen::RowVectorXd &datum,
       const bool update_params = false,
-      const Eigen::VectorXd &covariate = Eigen::VectorXd(0)) = 0;
+      const Eigen::RowVectorXd &covariate = Eigen::RowVectorXd(0)) = 0;
   //! Removes a datum and its index from the hierarchy
   virtual void remove_datum(
-      const int id, const Eigen::VectorXd &datum,
+      const int id, const Eigen::RowVectorXd &datum,
       const bool update_params = false,
-      const Eigen::VectorXd &covariate = Eigen::VectorXd(0)) = 0;
+      const Eigen::RowVectorXd &covariate = Eigen::RowVectorXd(0)) = 0;
 
   virtual void initialize() = 0;
 
@@ -60,19 +60,19 @@ class AbstractHierarchy {
   //! Evaluates the log-likelihood of data in a single point
   virtual double like_lpdf(
       const Eigen::RowVectorXd &datum,
-      const Eigen::RowVectorXd &covariate = Eigen::VectorXd(0)) const = 0;
+      const Eigen::RowVectorXd &covariate = Eigen::RowVectorXd(0)) const = 0;
 
   //! Evaluates the log-marginal distribution of data in a single point
   virtual double prior_pred_lpdf(
       const Eigen::RowVectorXd &datum,
-      const Eigen::RowVectorXd &covariate = Eigen::VectorXd(0)) const {
+      const Eigen::RowVectorXd &covariate = Eigen::RowVectorXd(0)) const {
     throw std::runtime_error(
         "Cannot call prior_pred_lpdf() from a non-conjugate hieararchy");
   }
 
   virtual double conditional_pred_lpdf(
       const Eigen::RowVectorXd &datum,
-      const Eigen::RowVectorXd &covariate = Eigen::VectorXd(0)) const {
+      const Eigen::RowVectorXd &covariate = Eigen::RowVectorXd(0)) const {
     throw std::runtime_error(
         "Cannot call conditional_pred_lpdf() from a non-conjugate hieararchy");
   }

--- a/src/hierarchies/abstract_hierarchy.h
+++ b/src/hierarchies/abstract_hierarchy.h
@@ -67,15 +67,14 @@ class AbstractHierarchy {
       const Eigen::RowVectorXd &datum,
       const Eigen::RowVectorXd &covariate = Eigen::VectorXd(0)) const {
     throw std::runtime_error(
-        "You are callign 'prior_pred_lpdf' from a non conjugate hieararchy");
+        "Cannot call prior_pred_lpdf() from a non-conjugate hieararchy");
   }
 
   virtual double conditional_pred_lpdf(
       const Eigen::RowVectorXd &datum,
       const Eigen::RowVectorXd &covariate = Eigen::VectorXd(0)) const {
     throw std::runtime_error(
-        "You are callign 'conditional_pred_lpdf' from a non conjugate "
-        "hieararchy");
+        "Cannot call conditional_pred_lpdf() from a non-conjugate hieararchy");
   }
 
   // EVALUATION FUNCTIONS FOR GRIDS OF POINTS
@@ -88,15 +87,14 @@ class AbstractHierarchy {
       const Eigen::MatrixXd &data,
       const Eigen::MatrixXd &covariates = Eigen::MatrixXd(0, 0)) const {
     throw std::runtime_error(
-        "You are callign 'prior_pred_lpdf_grid' from a non conjugate "
-        "hieararchy");
+        "Cannot call prior_pred_lpdf_grid() from a non-conjugate hieararchy");
   }
 
   virtual Eigen::VectorXd conditional_pred_lpdf_grid(
       const Eigen::MatrixXd &data,
       const Eigen::MatrixXd &covariates = Eigen::MatrixXd(0, 0)) const {
     throw std::runtime_error(
-        "You are callign 'conditional_pred_lpdf_grid' from a non conjugate "
+        "Cannot call conditional_pred_lpdf_grid() from a non-conjugate "
         "hieararchy");
   }
 

--- a/src/hierarchies/base_hierarchy.h
+++ b/src/hierarchies/base_hierarchy.h
@@ -169,7 +169,8 @@ void BaseHierarchy<Derived, State, Hyperparams, Prior>::sample_full_cond(
       static_cast<Derived *>(this)->add_datum(i, data.row(i), false,
                                               covariates.row(i));
   }
-  static_cast<Derived *>(this)->sample_full_cond();
+  static_cast<Derived *>(this)->sample_full_cond();  // TODO is it correct...
+                 // ...that here we use the default bool update_params = false?
 }
 
 #endif  // BAYESMIX_HIERARCHIES_BASE_HIERARCHY_H_

--- a/src/hierarchies/base_hierarchy.h
+++ b/src/hierarchies/base_hierarchy.h
@@ -62,14 +62,14 @@ class BaseHierarchy : public AbstractHierarchy {
   }
 
   void add_datum(
-      const int id, const Eigen::VectorXd &datum,
+      const int id, const Eigen::RowVectorXd &datum,
       const bool update_params = false,
-      const Eigen::VectorXd &covariate = Eigen::VectorXd(0)) override;
+      const Eigen::RowVectorXd &covariate = Eigen::RowVectorXd(0)) override;
   //! Removes a datum and its index from the hierarchy
   void remove_datum(
-      const int id, const Eigen::VectorXd &datum,
+      const int id, const Eigen::RowVectorXd &datum,
       const bool update_params = false,
-      const Eigen::VectorXd &covariate = Eigen::VectorXd(0)) override;
+      const Eigen::RowVectorXd &covariate = Eigen::RowVectorXd(0)) override;
 
   void check_prior_is_set() const;
 
@@ -95,9 +95,9 @@ class BaseHierarchy : public AbstractHierarchy {
 
 template <class Derived, typename State, typename Hyperparams, typename Prior>
 void BaseHierarchy<Derived, State, Hyperparams, Prior>::add_datum(
-    const int id, const Eigen::VectorXd &datum,
+    const int id, const Eigen::RowVectorXd &datum,
     const bool update_params /*= false*/,
-    const Eigen::VectorXd &covariate /*= Eigen::VectorXd(0)*/) {
+    const Eigen::RowVectorXd &covariate /*= Eigen::RowVectorXd(0)*/) {
   assert(cluster_data_idx.find(id) == cluster_data_idx.end());
   card += 1;
   log_card = std::log(card);
@@ -111,9 +111,9 @@ void BaseHierarchy<Derived, State, Hyperparams, Prior>::add_datum(
 
 template <class Derived, typename State, typename Hyperparams, typename Prior>
 void BaseHierarchy<Derived, State, Hyperparams, Prior>::remove_datum(
-    const int id, const Eigen::VectorXd &datum,
+    const int id, const Eigen::RowVectorXd &datum,
     const bool update_params /*= false*/,
-    const Eigen::VectorXd &covariate /* = Eigen::VectorXd(0)*/) {
+    const Eigen::RowVectorXd &covariate /* = Eigen::RowVectorXd(0)*/) {
   static_cast<Derived *>(this)->update_summary_statistics(datum, covariate,
                                                           false);
   card -= 1;

--- a/src/hierarchies/base_hierarchy.h
+++ b/src/hierarchies/base_hierarchy.h
@@ -169,7 +169,7 @@ void BaseHierarchy<Derived, State, Hyperparams, Prior>::sample_full_cond(
       static_cast<Derived *>(this)->add_datum(i, data.row(i), false,
                                               covariates.row(i));
   }
-  static_cast<Derived *>(this)->sample_full_cond(false);
+  static_cast<Derived *>(this)->sample_full_cond(true);
 }
 
 #endif  // BAYESMIX_HIERARCHIES_BASE_HIERARCHY_H_

--- a/src/hierarchies/base_hierarchy.h
+++ b/src/hierarchies/base_hierarchy.h
@@ -169,8 +169,7 @@ void BaseHierarchy<Derived, State, Hyperparams, Prior>::sample_full_cond(
       static_cast<Derived *>(this)->add_datum(i, data.row(i), false,
                                               covariates.row(i));
   }
-  static_cast<Derived *>(this)->sample_full_cond();  // TODO is it correct...
-                 // ...that here we use the default bool update_params = false?
+  static_cast<Derived *>(this)->sample_full_cond(false);
 }
 
 #endif  // BAYESMIX_HIERARCHIES_BASE_HIERARCHY_H_

--- a/src/hierarchies/base_hierarchy.h
+++ b/src/hierarchies/base_hierarchy.h
@@ -10,8 +10,8 @@
 #include <stan/math/prim.hpp>
 
 #include "abstract_hierarchy.h"
+#include "algorithm_state.pb.h"
 #include "hierarchy_id.pb.h"
-#include "marginal_state.pb.h"
 #include "src/utils/rng.h"
 
 template <class Derived, typename State, typename Hyperparams, typename Prior>

--- a/src/hierarchies/conjugate_hierarchy.h
+++ b/src/hierarchies/conjugate_hierarchy.h
@@ -36,9 +36,9 @@ class ConjugateHierarchy
 
   //! Generates new values for state from the centering posterior distribution
   void sample_full_cond(bool update_params = true) override {
-    if (card == 0) {
+    if (this->card == 0) {
       // No posterior update possible
-      sample_prior();
+      static_cast<Derived *>(this)->sample_prior();
     } else {
       Hyperparams params =
           update_params

--- a/src/hierarchies/conjugate_hierarchy.h
+++ b/src/hierarchies/conjugate_hierarchy.h
@@ -36,11 +36,16 @@ class ConjugateHierarchy
 
   //! Generates new values for state from the centering posterior distribution
   void sample_full_cond(bool update_params = true) override {
-    Hyperparams params =
-        update_params
-            ? static_cast<Derived *>(this)->get_posterior_parameters()
-            : posterior_hypers;
-    state = static_cast<Derived *>(this)->draw(params);
+    if (card == 0) {
+      // No posterior update possible
+      sample_prior();
+    } else {
+      Hyperparams params =
+          update_params
+              ? static_cast<Derived *>(this)->get_posterior_parameters()
+              : posterior_hypers;
+      state = static_cast<Derived *>(this)->draw(params);
+    }
   }
 
   //! Evaluates the log-marginal of data in a grid of points

--- a/src/hierarchies/lin_reg_uni_hierarchy.cc
+++ b/src/hierarchies/lin_reg_uni_hierarchy.cc
@@ -10,14 +10,14 @@
 
 double LinRegUniHierarchy::like_lpdf(
     const Eigen::RowVectorXd &datum,
-    const Eigen::RowVectorXd &covariate /*= Eigen::VectorXd(0)*/) const {
+    const Eigen::RowVectorXd &covariate /*= Eigen::RowVectorXd(0)*/) const {
   return stan::math::normal_lpdf(
       datum(0), state.regression_coeffs.dot(covariate), sqrt(state.var));
 }
 
 double LinRegUniHierarchy::marg_lpdf(
     const LinRegUni::Hyperparams &params, const Eigen::RowVectorXd &datum,
-    const Eigen::RowVectorXd &covariate /*= Eigen::VectorXd(0)*/) const {
+    const Eigen::RowVectorXd &covariate /*= Eigen::RowVectorXd(0)*/) const {
   double sig_n = sqrt(
       (1 + (covariate * params.var_scaling_inv * covariate.transpose())(0)) *
       params.scale / params.shape);
@@ -36,15 +36,15 @@ LinRegUni::State LinRegUniHierarchy::draw(
 }
 
 void LinRegUniHierarchy::update_summary_statistics(
-    const Eigen::VectorXd &datum, const Eigen::VectorXd &covariate, bool add) {
+    const Eigen::RowVectorXd &datum, const Eigen::RowVectorXd &covariate, bool add) {
   if (add) {
     data_sum_squares += datum(0) * datum(0);
-    covar_sum_squares += covariate * covariate.transpose();
-    mixed_prod += datum(0) * covariate;
+    covar_sum_squares += covariate.transpose() * covariate;
+    mixed_prod += datum(0) * covariate.transpose();
   } else {
     data_sum_squares -= datum(0) * datum(0);
-    covar_sum_squares -= covariate * covariate.transpose();
-    mixed_prod -= datum(0) * covariate;
+    covar_sum_squares -= covariate.transpose() * covariate;
+    mixed_prod -= datum(0) * covariate.transpose();
   }
 }
 

--- a/src/hierarchies/lin_reg_uni_hierarchy.cc
+++ b/src/hierarchies/lin_reg_uni_hierarchy.cc
@@ -36,7 +36,8 @@ LinRegUni::State LinRegUniHierarchy::draw(
 }
 
 void LinRegUniHierarchy::update_summary_statistics(
-    const Eigen::RowVectorXd &datum, const Eigen::RowVectorXd &covariate, bool add) {
+    const Eigen::RowVectorXd &datum, const Eigen::RowVectorXd &covariate,
+    bool add) {
   if (add) {
     data_sum_squares += datum(0) * datum(0);
     covar_sum_squares += covariate.transpose() * covariate;

--- a/src/hierarchies/lin_reg_uni_hierarchy.cc
+++ b/src/hierarchies/lin_reg_uni_hierarchy.cc
@@ -112,7 +112,7 @@ void LinRegUniHierarchy::initialize_hypers() {
 }
 
 void LinRegUniHierarchy::update_hypers(
-    const std::vector<bayesmix::MarginalState::ClusterState> &states) {
+    const std::vector<bayesmix::AlgorithmState::ClusterState> &states) {
   auto &rng = bayesmix::Rng::Instance().get();
   if (prior->has_fixed_values()) {
     return;
@@ -126,7 +126,7 @@ void LinRegUniHierarchy::update_hypers(
 void LinRegUniHierarchy::set_state_from_proto(
     const google::protobuf::Message &state_) {
   auto &statecast = google::protobuf::internal::down_cast<
-      const bayesmix::MarginalState::ClusterState &>(state_);
+      const bayesmix::AlgorithmState::ClusterState &>(state_);
   state.regression_coeffs =
       bayesmix::to_eigen(statecast.lin_reg_uni_ls_state().regression_coeffs());
   state.var = statecast.lin_reg_uni_ls_state().var();
@@ -141,7 +141,7 @@ void LinRegUniHierarchy::write_state_to_proto(
   state_.set_var(state.var);
 
   auto *out_cast = google::protobuf::internal::down_cast<
-      bayesmix::MarginalState::ClusterState *>(out);
+      bayesmix::AlgorithmState::ClusterState *>(out);
   out_cast->mutable_lin_reg_uni_ls_state()->CopyFrom(state_);
   out_cast->set_cardinality(card);
 }

--- a/src/hierarchies/lin_reg_uni_hierarchy.h
+++ b/src/hierarchies/lin_reg_uni_hierarchy.h
@@ -53,11 +53,11 @@ class LinRegUniHierarchy
   //! Evaluates the log-likelihood of data in a single point
   double like_lpdf(
       const Eigen::RowVectorXd &datum,
-      const Eigen::RowVectorXd &covariate = Eigen::VectorXd(0)) const override;
+      const Eigen::RowVectorXd &covariate = Eigen::RowVectorXd(0)) const override;
 
   double marg_lpdf(
       const LinRegUni::Hyperparams &params, const Eigen::RowVectorXd &datum,
-      const Eigen::RowVectorXd &covariate = Eigen::VectorXd(0)) const;
+      const Eigen::RowVectorXd &covariate = Eigen::RowVectorXd(0)) const;
 
   LinRegUni::State draw(const LinRegUni::Hyperparams &params);
 
@@ -67,8 +67,8 @@ class LinRegUniHierarchy
 
   void initialize_state();
   void initialize_hypers();
-  void update_summary_statistics(const Eigen::VectorXd &datum,
-                                 const Eigen::VectorXd &covariate, bool add);
+  void update_summary_statistics(const Eigen::RowVectorXd &datum,
+                                 const Eigen::RowVectorXd &covariate, bool add);
   LinRegUni::Hyperparams get_posterior_parameters();
 
   void set_state_from_proto(const google::protobuf::Message &state_) override;

--- a/src/hierarchies/lin_reg_uni_hierarchy.h
+++ b/src/hierarchies/lin_reg_uni_hierarchy.h
@@ -51,9 +51,9 @@ class LinRegUniHierarchy
 
   // EVALUATION FUNCTIONS
   //! Evaluates the log-likelihood of data in a single point
-  double like_lpdf(
-      const Eigen::RowVectorXd &datum,
-      const Eigen::RowVectorXd &covariate = Eigen::RowVectorXd(0)) const override;
+  double like_lpdf(const Eigen::RowVectorXd &datum,
+                   const Eigen::RowVectorXd &covariate =
+                       Eigen::RowVectorXd(0)) const override;
 
   double marg_lpdf(
       const LinRegUni::Hyperparams &params, const Eigen::RowVectorXd &datum,
@@ -68,7 +68,8 @@ class LinRegUniHierarchy
   void initialize_state();
   void initialize_hypers();
   void update_summary_statistics(const Eigen::RowVectorXd &datum,
-                                 const Eigen::RowVectorXd &covariate, bool add);
+                                 const Eigen::RowVectorXd &covariate,
+                                 bool add);
   LinRegUni::Hyperparams get_posterior_parameters();
 
   void set_state_from_proto(const google::protobuf::Message &state_) override;

--- a/src/hierarchies/lin_reg_uni_hierarchy.h
+++ b/src/hierarchies/lin_reg_uni_hierarchy.h
@@ -7,10 +7,10 @@
 #include <memory>
 #include <vector>
 
+#include "algorithm_state.pb.h"
 #include "conjugate_hierarchy.h"
 #include "hierarchy_id.pb.h"
 #include "hierarchy_prior.pb.h"
-#include "marginal_state.pb.h"
 
 namespace LinRegUni {
 struct State {
@@ -63,7 +63,7 @@ class LinRegUniHierarchy
 
   void clear_data();
   void update_hypers(
-      const std::vector<bayesmix::MarginalState::ClusterState> &states);
+      const std::vector<bayesmix::AlgorithmState::ClusterState> &states);
 
   void initialize_state();
   void initialize_hypers();

--- a/src/hierarchies/nnig_hierarchy.cc
+++ b/src/hierarchies/nnig_hierarchy.cc
@@ -6,9 +6,9 @@
 #include <stan/math/prim/prob.hpp>
 #include <vector>
 
+#include "algorithm_state.pb.h"
 #include "hierarchy_prior.pb.h"
 #include "ls_state.pb.h"
-#include "marginal_state.pb.h"
 #include "src/utils/rng.h"
 
 double NNIGHierarchy::like_lpdf(
@@ -162,7 +162,7 @@ void NNIGHierarchy::initialize_hypers() {
 }
 
 void NNIGHierarchy::update_hypers(
-    const std::vector<bayesmix::MarginalState::ClusterState> &states) {
+    const std::vector<bayesmix::AlgorithmState::ClusterState> &states) {
   auto &rng = bayesmix::Rng::Instance().get();
 
   if (prior->has_fixed_values()) {
@@ -235,7 +235,7 @@ void NNIGHierarchy::update_hypers(
 void NNIGHierarchy::set_state_from_proto(
     const google::protobuf::Message &state_) {
   auto &statecast = google::protobuf::internal::down_cast<
-      const bayesmix::MarginalState::ClusterState &>(state_);
+      const bayesmix::AlgorithmState::ClusterState &>(state_);
   state.mean = statecast.uni_ls_state().mean();
   state.var = statecast.uni_ls_state().var();
   set_card(statecast.cardinality());
@@ -248,7 +248,7 @@ void NNIGHierarchy::write_state_to_proto(
   state_.set_var(state.var);
 
   auto *out_cast = google::protobuf::internal::down_cast<
-      bayesmix::MarginalState::ClusterState *>(out);
+      bayesmix::AlgorithmState::ClusterState *>(out);
   out_cast->mutable_uni_ls_state()->CopyFrom(state_);
   out_cast->set_cardinality(card);
 }

--- a/src/hierarchies/nnig_hierarchy.cc
+++ b/src/hierarchies/nnig_hierarchy.cc
@@ -13,13 +13,13 @@
 
 double NNIGHierarchy::like_lpdf(
     const Eigen::RowVectorXd &datum,
-    const Eigen::RowVectorXd &covariate /*= Eigen::VectorXd(0)*/) const {
+    const Eigen::RowVectorXd &covariate /*= Eigen::RowVectorXd(0)*/) const {
   return stan::math::normal_lpdf(datum(0), state.mean, sqrt(state.var));
 }
 
 double NNIGHierarchy::marg_lpdf(
     const NNIG::Hyperparams &params, const Eigen::RowVectorXd &datum,
-    const Eigen::RowVectorXd &covariate /*= Eigen::VectorXd(0)*/) const {
+    const Eigen::RowVectorXd &covariate /*= Eigen::RowVectorXd(0)*/) const {
   double sig_n = sqrt(params.scale * (params.var_scaling + 1) /
                       (params.shape * params.var_scaling));
   return stan::math::student_t_lpdf(datum(0), 2 * params.shape, params.mean,
@@ -36,8 +36,8 @@ NNIG::State NNIGHierarchy::draw(const NNIG::Hyperparams &params) {
   return out;
 }
 
-void NNIGHierarchy::update_summary_statistics(const Eigen::VectorXd &datum,
-                                              const Eigen::VectorXd &covariate,
+void NNIGHierarchy::update_summary_statistics(const Eigen::RowVectorXd &datum,
+                                              const Eigen::RowVectorXd &covariate,
                                               bool add) {
   if (add) {
     data_sum += datum(0);

--- a/src/hierarchies/nnig_hierarchy.cc
+++ b/src/hierarchies/nnig_hierarchy.cc
@@ -36,9 +36,9 @@ NNIG::State NNIGHierarchy::draw(const NNIG::Hyperparams &params) {
   return out;
 }
 
-void NNIGHierarchy::update_summary_statistics(const Eigen::RowVectorXd &datum,
-                                              const Eigen::RowVectorXd &covariate,
-                                              bool add) {
+void NNIGHierarchy::update_summary_statistics(
+    const Eigen::RowVectorXd &datum, const Eigen::RowVectorXd &covariate,
+    bool add) {
   if (add) {
     data_sum += datum(0);
     data_sum_squares += datum(0) * datum(0);

--- a/src/hierarchies/nnig_hierarchy.h
+++ b/src/hierarchies/nnig_hierarchy.h
@@ -7,10 +7,10 @@
 #include <memory>
 #include <vector>
 
+#include "algorithm_state.pb.h"
 #include "conjugate_hierarchy.h"
 #include "hierarchy_id.pb.h"
 #include "hierarchy_prior.pb.h"
-#include "marginal_state.pb.h"
 
 //! Normal Normal-InverseGamma hierarchy for univariate data.
 
@@ -68,7 +68,7 @@ class NNIGHierarchy
 
   void clear_data();
   void update_hypers(
-      const std::vector<bayesmix::MarginalState::ClusterState> &states);
+      const std::vector<bayesmix::AlgorithmState::ClusterState> &states);
   void initialize_state();
   void initialize_hypers();
   void update_summary_statistics(const Eigen::VectorXd &datum,

--- a/src/hierarchies/nnig_hierarchy.h
+++ b/src/hierarchies/nnig_hierarchy.h
@@ -56,9 +56,9 @@ class NNIGHierarchy
 
   // EVALUATION FUNCTIONS
   //! Evaluates the log-likelihood of data in a single point
-  double like_lpdf(
-      const Eigen::RowVectorXd &datum,
-      const Eigen::RowVectorXd &covariate = Eigen::RowVectorXd(0)) const override;
+  double like_lpdf(const Eigen::RowVectorXd &datum,
+                   const Eigen::RowVectorXd &covariate =
+                       Eigen::RowVectorXd(0)) const override;
   //! Evaluates the log-marginal distribution of data in a single point
   double marg_lpdf(
       const NNIG::Hyperparams &params, const Eigen::RowVectorXd &datum,
@@ -72,7 +72,8 @@ class NNIGHierarchy
   void initialize_state();
   void initialize_hypers();
   void update_summary_statistics(const Eigen::RowVectorXd &datum,
-                                 const Eigen::RowVectorXd &covariate, bool add);
+                                 const Eigen::RowVectorXd &covariate,
+                                 bool add);
   NNIG::Hyperparams get_posterior_parameters();
 
   void set_state_from_proto(const google::protobuf::Message &state_) override;

--- a/src/hierarchies/nnig_hierarchy.h
+++ b/src/hierarchies/nnig_hierarchy.h
@@ -58,11 +58,11 @@ class NNIGHierarchy
   //! Evaluates the log-likelihood of data in a single point
   double like_lpdf(
       const Eigen::RowVectorXd &datum,
-      const Eigen::RowVectorXd &covariate = Eigen::VectorXd(0)) const override;
+      const Eigen::RowVectorXd &covariate = Eigen::RowVectorXd(0)) const override;
   //! Evaluates the log-marginal distribution of data in a single point
   double marg_lpdf(
       const NNIG::Hyperparams &params, const Eigen::RowVectorXd &datum,
-      const Eigen::RowVectorXd &covariate = Eigen::VectorXd(0)) const;
+      const Eigen::RowVectorXd &covariate = Eigen::RowVectorXd(0)) const;
 
   NNIG::State draw(const NNIG::Hyperparams &params);
 
@@ -71,8 +71,8 @@ class NNIGHierarchy
       const std::vector<bayesmix::AlgorithmState::ClusterState> &states);
   void initialize_state();
   void initialize_hypers();
-  void update_summary_statistics(const Eigen::VectorXd &datum,
-                                 const Eigen::VectorXd &covariate, bool add);
+  void update_summary_statistics(const Eigen::RowVectorXd &datum,
+                                 const Eigen::RowVectorXd &covariate, bool add);
   NNIG::Hyperparams get_posterior_parameters();
 
   void set_state_from_proto(const google::protobuf::Message &state_) override;

--- a/src/hierarchies/nnw_hierarchy.cc
+++ b/src/hierarchies/nnw_hierarchy.cc
@@ -6,9 +6,9 @@
 #include <stan/math/prim.hpp>
 #include <vector>
 
+#include "algorithm_state.pb.h"
 #include "hierarchy_prior.pb.h"
 #include "ls_state.pb.h"
-#include "marginal_state.pb.h"
 #include "matrix.pb.h"
 #include "src/utils/distributions.h"
 #include "src/utils/eigen_utils.h"
@@ -219,7 +219,7 @@ void NNWHierarchy::initialize_hypers() {
 }
 
 void NNWHierarchy::update_hypers(
-    const std::vector<bayesmix::MarginalState::ClusterState> &states) {
+    const std::vector<bayesmix::AlgorithmState::ClusterState> &states) {
   auto &rng = bayesmix::Rng::Instance().get();
   if (prior->has_fixed_values()) {
     return;
@@ -298,7 +298,7 @@ void NNWHierarchy::update_hypers(
 void NNWHierarchy::set_state_from_proto(
     const google::protobuf::Message &state_) {
   auto &statecast = google::protobuf::internal::down_cast<
-      const bayesmix::MarginalState::ClusterState &>(state_);
+      const bayesmix::AlgorithmState::ClusterState &>(state_);
   state.mean = to_eigen(statecast.multi_ls_state().mean());
   wite_prec_to_state(to_eigen(statecast.multi_ls_state().prec()), &state);
   set_card(statecast.cardinality());
@@ -309,7 +309,7 @@ void NNWHierarchy::write_state_to_proto(google::protobuf::Message *out) const {
   bayesmix::to_proto(state.mean, state_.mutable_mean());
   bayesmix::to_proto(state.prec, state_.mutable_prec());
   auto *out_cast = google::protobuf::internal::down_cast<
-      bayesmix::MarginalState::ClusterState *>(out);
+      bayesmix::AlgorithmState::ClusterState *>(out);
   out_cast->mutable_multi_ls_state()->CopyFrom(state_);
   out_cast->set_cardinality(card);
 }

--- a/src/hierarchies/nnw_hierarchy.cc
+++ b/src/hierarchies/nnw_hierarchy.cc
@@ -29,7 +29,7 @@ void NNWHierarchy::wite_prec_to_state(const Eigen::MatrixXd &prec_,
 //! \return     Log-Likehood vector evaluated in data
 double NNWHierarchy::like_lpdf(
     const Eigen::RowVectorXd &datum,
-    const Eigen::RowVectorXd &covariate /*= Eigen::VectorXd(0)*/) const {
+    const Eigen::RowVectorXd &covariate /*= Eigen::RowVectorXd(0)*/) const {
   // Initialize relevant objects
   return bayesmix::multi_normal_prec_lpdf(datum, state.mean, state.prec_chol,
                                           state.prec_logdet);
@@ -37,7 +37,7 @@ double NNWHierarchy::like_lpdf(
 
 double NNWHierarchy::marg_lpdf(
     const NNW::Hyperparams &params, const Eigen::RowVectorXd &datum,
-    const Eigen::RowVectorXd &covariate /*= Eigen::VectorXd(0)*/) const {
+    const Eigen::RowVectorXd &covariate /*= Eigen::RowVectorXd(0)*/) const {
   // Compute dof and scale of marginal distribution
   double nu_n = 2 * params.deg_free - dim + 1;
   Eigen::MatrixXd sigma_n = params.scale_inv *
@@ -60,15 +60,15 @@ NNW::State NNWHierarchy::draw(const NNW::Hyperparams &params) {
   return out;
 }
 
-void NNWHierarchy::update_summary_statistics(const Eigen::VectorXd &datum,
-                                             const Eigen::VectorXd &covariate,
+void NNWHierarchy::update_summary_statistics(const Eigen::RowVectorXd &datum,
+                                             const Eigen::RowVectorXd &covariate,
                                              bool add) {
   if (add) {
-    data_sum += datum;
-    data_sum_squares += datum * datum.transpose();
+    data_sum += datum.transpose();
+    data_sum_squares += datum.transpose() * datum;
   } else {
-    data_sum -= datum;
-    data_sum_squares -= datum * datum.transpose();
+    data_sum -= datum.transpose();
+    data_sum_squares -= datum.transpose() * datum;
   }
 }
 

--- a/src/hierarchies/nnw_hierarchy.cc
+++ b/src/hierarchies/nnw_hierarchy.cc
@@ -60,9 +60,9 @@ NNW::State NNWHierarchy::draw(const NNW::Hyperparams &params) {
   return out;
 }
 
-void NNWHierarchy::update_summary_statistics(const Eigen::RowVectorXd &datum,
-                                             const Eigen::RowVectorXd &covariate,
-                                             bool add) {
+void NNWHierarchy::update_summary_statistics(
+    const Eigen::RowVectorXd &datum, const Eigen::RowVectorXd &covariate,
+    bool add) {
   if (add) {
     data_sum += datum.transpose();
     data_sum_squares += datum.transpose() * datum;

--- a/src/hierarchies/nnw_hierarchy.h
+++ b/src/hierarchies/nnw_hierarchy.h
@@ -7,10 +7,10 @@
 #include <memory>
 #include <vector>
 
+#include "algorithm_state.pb.h"
 #include "conjugate_hierarchy.h"
 #include "hierarchy_id.pb.h"
 #include "hierarchy_prior.pb.h"
-#include "marginal_state.pb.h"
 
 //! Normal Normal-Wishart hierarchy for multivariate data.
 
@@ -79,7 +79,7 @@ class NNWHierarchy
 
   void clear_data();
   void update_hypers(
-      const std::vector<bayesmix::MarginalState::ClusterState> &states);
+      const std::vector<bayesmix::AlgorithmState::ClusterState> &states);
 
   void initialize_state();
   void initialize_hypers();

--- a/src/hierarchies/nnw_hierarchy.h
+++ b/src/hierarchies/nnw_hierarchy.h
@@ -68,11 +68,11 @@ class NNWHierarchy
   //! Evaluates the log-likelihood of data in a single point
   double like_lpdf(
       const Eigen::RowVectorXd &datum,
-      const Eigen::RowVectorXd &covariate = Eigen::VectorXd(0)) const override;
+      const Eigen::RowVectorXd &covariate = Eigen::RowVectorXd(0)) const override;
 
   double marg_lpdf(
       const NNW::Hyperparams &params, const Eigen::RowVectorXd &datum,
-      const Eigen::RowVectorXd &covariate = Eigen::VectorXd(0)) const;
+      const Eigen::RowVectorXd &covariate = Eigen::RowVectorXd(0)) const;
 
   // SAMPLING FUNCTIONS
   NNW::State draw(const NNW::Hyperparams &params);
@@ -83,8 +83,8 @@ class NNWHierarchy
 
   void initialize_state();
   void initialize_hypers();
-  void update_summary_statistics(const Eigen::VectorXd &datum,
-                                 const Eigen::VectorXd &covariate, bool add);
+  void update_summary_statistics(const Eigen::RowVectorXd &datum,
+                                 const Eigen::RowVectorXd &covariate, bool add);
   NNW::Hyperparams get_posterior_parameters();
 
   void set_state_from_proto(const google::protobuf::Message &state_) override;

--- a/src/hierarchies/nnw_hierarchy.h
+++ b/src/hierarchies/nnw_hierarchy.h
@@ -66,9 +66,9 @@ class NNWHierarchy
 
   // EVALUATION FUNCTIONS
   //! Evaluates the log-likelihood of data in a single point
-  double like_lpdf(
-      const Eigen::RowVectorXd &datum,
-      const Eigen::RowVectorXd &covariate = Eigen::RowVectorXd(0)) const override;
+  double like_lpdf(const Eigen::RowVectorXd &datum,
+                   const Eigen::RowVectorXd &covariate =
+                       Eigen::RowVectorXd(0)) const override;
 
   double marg_lpdf(
       const NNW::Hyperparams &params, const Eigen::RowVectorXd &datum,
@@ -84,7 +84,8 @@ class NNWHierarchy
   void initialize_state();
   void initialize_hypers();
   void update_summary_statistics(const Eigen::RowVectorXd &datum,
-                                 const Eigen::RowVectorXd &covariate, bool add);
+                                 const Eigen::RowVectorXd &covariate,
+                                 bool add);
   NNW::Hyperparams get_posterior_parameters();
 
   void set_state_from_proto(const google::protobuf::Message &state_) override;

--- a/src/mixings/base_mixing.h
+++ b/src/mixings/base_mixing.h
@@ -21,6 +21,8 @@ class BaseMixing {
   std::shared_ptr<google::protobuf::Message> prior;
   //!
   const Eigen::MatrixXd *covariates_ptr;
+  //!
+  unsigned int num_components;
 
   //!
   virtual void create_empty_prior() = 0;
@@ -44,12 +46,14 @@ class BaseMixing {
       const std::vector<unsigned int> &allocations) = 0;
 
   // GETTERS AND SETTERS
+  unsigned int get_num_components() const { return num_components; }
   google::protobuf::Message *get_mutable_prior() {
     if (prior == nullptr) {
       create_empty_prior();
     }
     return prior.get();
   }
+  void set_num_components(const unsigned int num_) { num_components = num_; }
   void set_covariates(Eigen::MatrixXd *covar) { covariates_ptr = covar; }
   virtual void set_state_from_proto(
       const google::protobuf::Message &state_) = 0;

--- a/src/mixings/conditional_mixing.h
+++ b/src/mixings/conditional_mixing.h
@@ -13,6 +13,7 @@ class ConditionalMixing : public BaseMixing {
   bool is_conditional() const override { return true; }
   //!
   virtual Eigen::VectorXd get_weights(
+      const bool log, const bool propto,
       const Eigen::VectorXd &covariate = Eigen::VectorXd(0)) const = 0;
 };
 

--- a/src/mixings/conditional_mixing.h
+++ b/src/mixings/conditional_mixing.h
@@ -14,7 +14,7 @@ class ConditionalMixing : public BaseMixing {
   //!
   virtual Eigen::VectorXd get_weights(
       const bool log, const bool propto,
-      const Eigen::VectorXd &covariate = Eigen::VectorXd(0)) const = 0;
+      const Eigen::RowVectorXd &covariate = Eigen::RowVectorXd(0)) const = 0;
 };
 
 #endif  // BAYESMIX_MIXINGS_CONDITIONAL_MIXING_H_

--- a/src/mixings/logit_sb_mixing.cc
+++ b/src/mixings/logit_sb_mixing.cc
@@ -142,6 +142,7 @@ void LogitSBMixing::write_state_to_proto(
 }
 
 Eigen::VectorXd LogitSBMixing::get_weights(
+    const bool log, const bool propto,
     const Eigen::VectorXd &covariate /*= Eigen::VectorXd(0)*/) const {
   // Compute eta
   std::vector<double> eta(num_components - 1);
@@ -161,5 +162,10 @@ Eigen::VectorXd LogitSBMixing::get_weights(
   weights(num_components - 1) =
       1.0 - std::accumulate(weights.data(),
                             weights.data() + num_components - 1, 0.0);
+  if (log) {
+    for (int h = 0; h < num_components; h++) {
+      weights(h) = std::log(weights(h));
+    }
+  }
   return weights;
 }

--- a/src/mixings/logit_sb_mixing.cc
+++ b/src/mixings/logit_sb_mixing.cc
@@ -144,7 +144,7 @@ void LogitSBMixing::write_state_to_proto(
 
 Eigen::VectorXd LogitSBMixing::get_weights(
     const bool log, const bool propto,
-    const Eigen::VectorXd &covariate /*= Eigen::VectorXd(0)*/) const {
+    const Eigen::RowVectorXd &covariate /*= Eigen::RowVectorXd(0)*/) const {
   // Compute eta
   std::vector<double> eta(num_components - 1);
   for (int h = 0; h < num_components - 1; h++) {

--- a/src/mixings/logit_sb_mixing.cc
+++ b/src/mixings/logit_sb_mixing.cc
@@ -163,9 +163,7 @@ Eigen::VectorXd LogitSBMixing::get_weights(
       1.0 - std::accumulate(weights.data(),
                             weights.data() + num_components - 1, 0.0);
   if (log) {
-    for (int h = 0; h < num_components; h++) {
-      weights(h) = std::log(weights(h));
-    }
+    weights = weights.array().log();
   }
   return weights;
 }

--- a/src/mixings/logit_sb_mixing.cc
+++ b/src/mixings/logit_sb_mixing.cc
@@ -137,8 +137,9 @@ void LogitSBMixing::write_state_to_proto(
   bayesmix::LogSBState state_;
   bayesmix::to_proto(state.regression_coeffs,
                      state_.mutable_regression_coeffs());
-  google::protobuf::internal::down_cast<bayesmix::LogSBState *>(out)->CopyFrom(
-      state_);
+  google::protobuf::internal::down_cast<bayesmix::MixingState *>(out)
+      ->mutable_log_sb_state()
+      ->CopyFrom(state_);
 }
 
 Eigen::VectorXd LogitSBMixing::get_weights(

--- a/src/mixings/logit_sb_mixing.cc
+++ b/src/mixings/logit_sb_mixing.cc
@@ -127,9 +127,10 @@ void LogitSBMixing::update_state(
 void LogitSBMixing::set_state_from_proto(
     const google::protobuf::Message &state_) {
   auto &statecast =
-      google::protobuf::internal::down_cast<const bayesmix::LogSBState &>(
+      google::protobuf::internal::down_cast<const bayesmix::MixingState &>(
           state_);
-  state.regression_coeffs = bayesmix::to_eigen(statecast.regression_coeffs());
+  state.regression_coeffs =
+      bayesmix::to_eigen(statecast.log_sb_state().regression_coeffs());
 }
 
 void LogitSBMixing::write_state_to_proto(

--- a/src/mixings/logit_sb_mixing.h
+++ b/src/mixings/logit_sb_mixing.h
@@ -50,9 +50,9 @@ class LogitSBMixing : public ConditionalMixing {
   ~LogitSBMixing() = default;
   LogitSBMixing() = default;
 
-  Eigen::VectorXd get_weights(
-      const bool log, const bool propto,
-      const Eigen::VectorXd &covariate = Eigen::VectorXd(0)) const override;
+  Eigen::VectorXd get_weights(const bool log, const bool propto,
+                              const Eigen::RowVectorXd &covariate =
+                                  Eigen::RowVectorXd(0)) const override;
 
   std::shared_ptr<BaseMixing> clone() const override {
     return std::make_shared<LogitSBMixing>(*this);

--- a/src/mixings/logit_sb_mixing.h
+++ b/src/mixings/logit_sb_mixing.h
@@ -21,7 +21,6 @@ class LogitSBMixing : public ConditionalMixing {
   };
 
  protected:
-  unsigned int num_components;
   unsigned int dim;
   State state;
   Eigen::VectorXd acceptance_rates;

--- a/src/mixings/logit_sb_mixing.h
+++ b/src/mixings/logit_sb_mixing.h
@@ -51,6 +51,7 @@ class LogitSBMixing : public ConditionalMixing {
   LogitSBMixing() = default;
 
   Eigen::VectorXd get_weights(
+      const bool log, const bool propto,
       const Eigen::VectorXd &covariate = Eigen::VectorXd(0)) const override;
 
   std::shared_ptr<BaseMixing> clone() const override {

--- a/src/utils/distributions.cc
+++ b/src/utils/distributions.cc
@@ -104,9 +104,9 @@ double bayesmix::gaussian_mixture_dist(std::vector<Eigen::VectorXd> means1,
 }
 
 double bayesmix::gaussian_mixture_dist(
-    std::vector<bayesmix::MarginalState::ClusterState> clus1,
+    std::vector<bayesmix::AlgorithmState::ClusterState> clus1,
     Eigen::VectorXd weights1,
-    std::vector<bayesmix::MarginalState::ClusterState> clus2,
+    std::vector<bayesmix::AlgorithmState::ClusterState> clus2,
     Eigen::VectorXd weights2) {
   double out;
 

--- a/src/utils/distributions.h
+++ b/src/utils/distributions.h
@@ -7,7 +7,7 @@
 #include <random>
 #include <vector>
 
-#include "marginal_state.pb.h"
+#include "algorithm_state.pb.h"
 
 namespace bayesmix {
 
@@ -94,9 +94,9 @@ double gaussian_mixture_dist(std::vector<Eigen::VectorXd> means1,
  * @return the L2 distance between p and q
  */
 double gaussian_mixture_dist(
-    std::vector<bayesmix::MarginalState::ClusterState> clus1,
+    std::vector<bayesmix::AlgorithmState::ClusterState> clus1,
     Eigen::VectorXd weights1,
-    std::vector<bayesmix::MarginalState::ClusterState> clus2,
+    std::vector<bayesmix::AlgorithmState::ClusterState> clus2,
     Eigen::VectorXd weights2);
 
 }  // namespace bayesmix

--- a/test/hierarchies.cc
+++ b/test/hierarchies.cc
@@ -3,8 +3,8 @@
 #include <Eigen/Dense>
 #include <stan/math/prim.hpp>
 
+#include "algorithm_state.pb.h"
 #include "ls_state.pb.h"
-#include "marginal_state.pb.h"
 #include "src/hierarchies/lin_reg_uni_hierarchy.h"
 #include "src/hierarchies/nnig_hierarchy.h"
 #include "src/hierarchies/nnw_hierarchy.h"
@@ -28,9 +28,9 @@ TEST(nnighierarchy, draw) {
   auto hier2 = hier->clone();
   hier2->sample_prior();
 
-  bayesmix::MarginalState out;
-  bayesmix::MarginalState::ClusterState* clusval = out.add_cluster_states();
-  bayesmix::MarginalState::ClusterState* clusval2 = out.add_cluster_states();
+  bayesmix::AlgorithmState out;
+  bayesmix::AlgorithmState::ClusterState* clusval = out.add_cluster_states();
+  bayesmix::AlgorithmState::ClusterState* clusval2 = out.add_cluster_states();
   hier->write_state_to_proto(clusval);
   hier2->write_state_to_proto(clusval2);
 
@@ -59,9 +59,9 @@ TEST(nnighierarchy, sample_given_data) {
   hier2->add_datum(0, datum, false);
   hier2->sample_full_cond();
 
-  bayesmix::MarginalState out;
-  bayesmix::MarginalState::ClusterState* clusval = out.add_cluster_states();
-  bayesmix::MarginalState::ClusterState* clusval2 = out.add_cluster_states();
+  bayesmix::AlgorithmState out;
+  bayesmix::AlgorithmState::ClusterState* clusval = out.add_cluster_states();
+  bayesmix::AlgorithmState::ClusterState* clusval2 = out.add_cluster_states();
   hier->write_state_to_proto(clusval);
   hier2->write_state_to_proto(clusval2);
 
@@ -90,9 +90,9 @@ TEST(nnwhierarchy, draw) {
   auto hier2 = hier->clone();
   hier2->sample_prior();
 
-  bayesmix::MarginalState out;
-  bayesmix::MarginalState::ClusterState* clusval = out.add_cluster_states();
-  bayesmix::MarginalState::ClusterState* clusval2 = out.add_cluster_states();
+  bayesmix::AlgorithmState out;
+  bayesmix::AlgorithmState::ClusterState* clusval = out.add_cluster_states();
+  bayesmix::AlgorithmState::ClusterState* clusval2 = out.add_cluster_states();
   hier->write_state_to_proto(clusval);
   hier2->write_state_to_proto(clusval2);
 
@@ -125,9 +125,9 @@ TEST(nnwhierarchy, sample_given_data) {
   hier2->add_datum(0, datum, false);
   hier2->sample_full_cond();
 
-  bayesmix::MarginalState out;
-  bayesmix::MarginalState::ClusterState* clusval = out.add_cluster_states();
-  bayesmix::MarginalState::ClusterState* clusval2 = out.add_cluster_states();
+  bayesmix::AlgorithmState out;
+  bayesmix::AlgorithmState::ClusterState* clusval = out.add_cluster_states();
+  bayesmix::AlgorithmState::ClusterState* clusval2 = out.add_cluster_states();
   hier->write_state_to_proto(clusval);
   hier2->write_state_to_proto(clusval2);
 
@@ -143,7 +143,7 @@ TEST(lin_reg_uni_hierarchy, state_read_write) {
   bayesmix::to_proto(beta, ls.mutable_regression_coeffs());
   ls.set_var(sigma2);
 
-  bayesmix::MarginalState::ClusterState state;
+  bayesmix::AlgorithmState::ClusterState state;
   state.mutable_lin_reg_uni_ls_state()->CopyFrom(ls);
 
   LinRegUniHierarchy hier;
@@ -152,8 +152,8 @@ TEST(lin_reg_uni_hierarchy, state_read_write) {
   ASSERT_EQ(hier.get_state().regression_coeffs, beta);
   ASSERT_EQ(hier.get_state().var, sigma2);
 
-  bayesmix::MarginalState outt;
-  bayesmix::MarginalState::ClusterState* out = outt.add_cluster_states();
+  bayesmix::AlgorithmState outt;
+  bayesmix::AlgorithmState::ClusterState* out = outt.add_cluster_states();
   hier.write_state_to_proto(out);
   ASSERT_EQ(beta, bayesmix::to_eigen(
                       out->lin_reg_uni_ls_state().regression_coeffs()));

--- a/test/logit_sb.cc
+++ b/test/logit_sb.cc
@@ -82,7 +82,10 @@ TEST(logit_sb, misc) {
   test2 << 5, 0;
   Eigen::VectorXd test3(2);
   test3 << 0, 5;
-  std::cout << "test1: " << mix.get_weights(test1).transpose() << std::endl;
-  std::cout << "test2: " << mix.get_weights(test2).transpose() << std::endl;
-  std::cout << "test3: " << mix.get_weights(test3).transpose() << std::endl;
+  std::cout << "test1: " << mix.get_weights(false, false, test1).transpose()
+            << std::endl;
+  std::cout << "test2: " << mix.get_weights(false, false, test2).transpose()
+            << std::endl;
+  std::cout << "test3: " << mix.get_weights(false, false, test3).transpose()
+            << std::endl;
 }

--- a/test/lpdf.cc
+++ b/test/lpdf.cc
@@ -4,7 +4,7 @@
 #include <stan/math/prim/fun.hpp>  // lgamma, lmgamma
 #include <stan/math/prim/prob.hpp>
 
-#include "marginal_state.pb.h"
+#include "algorithm_state.pb.h"
 #include "src/hierarchies/lin_reg_uni_hierarchy.h"
 #include "src/hierarchies/nnig_hierarchy.h"
 #include "src/hierarchies/nnw_hierarchy.h"

--- a/test/priors.cc
+++ b/test/priors.cc
@@ -3,7 +3,7 @@
 
 #include <memory>
 
-#include "marginal_state.pb.h"
+#include "algorithm_state.pb.h"
 #include "src/hierarchies/nnig_hierarchy.h"
 #include "src/hierarchies/nnw_hierarchy.h"
 #include "src/mixings/dirichlet_mixing.h"
@@ -63,7 +63,7 @@ TEST(hierarchies, fixed_values) {
   hier->initialize();
 
   std::vector<std::shared_ptr<AbstractHierarchy>> unique_values;
-  std::vector<bayesmix::MarginalState::ClusterState> states;
+  std::vector<bayesmix::AlgorithmState::ClusterState> states;
 
   // Check equality before update
   unique_values.push_back(hier);
@@ -100,7 +100,7 @@ TEST(hierarchies, normal_mean_prior) {
   bayesmix::to_proto(ident,
                      prior.mutable_normal_mean_prior()->mutable_scale());
 
-  std::vector<bayesmix::MarginalState::ClusterState> states(4);
+  std::vector<bayesmix::AlgorithmState::ClusterState> states(4);
   for (int i = 0; i < states.size(); i++) {
     double mean = 9.0 + i;
     Eigen::Vector2d vec;

--- a/test/runtime.cc
+++ b/test/runtime.cc
@@ -18,9 +18,9 @@ TEST(can_build, allmodels) {
       for (auto &hier_id : factory_hier.list_of_known_builders()) {
         auto hier = factory_hier.create_object(hier_id);
         if (hier->is_conjugate() & algo->requires_conjugate_hierarchy())
-          algo->set_initial_clusters(hier);
+          algo->set_hierarchy(hier);
         else if (!algo->requires_conjugate_hierarchy())
-          algo->set_initial_clusters(hier);
+          algo->set_hierarchy(hier);
       }
     }
   }

--- a/test/semi_hdp.cc
+++ b/test/semi_hdp.cc
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+
 #include <Eigen/Dense>
 #include <memory>
 #include <vector>

--- a/test/semi_hdp.cc
+++ b/test/semi_hdp.cc
@@ -1,6 +1,5 @@
 #include <gtest/gtest.h>
 
-
 #include <Eigen/Dense>
 #include <memory>
 #include <vector>

--- a/test/write_proto.cc
+++ b/test/write_proto.cc
@@ -1,7 +1,7 @@
 #include <gtest/gtest.h>
 
+#include "algorithm_state.pb.h"
 #include "ls_state.pb.h"
-#include "marginal_state.pb.h"
 #include "src/hierarchies/nnig_hierarchy.h"
 #include "src/hierarchies/nnw_hierarchy.h"
 #include "src/utils/proto_utils.h"
@@ -16,7 +16,7 @@ TEST(set_state, uni_ls) {
 
   ASSERT_EQ(curr.mean(), mean);
 
-  bayesmix::MarginalState::ClusterState clusval;
+  bayesmix::AlgorithmState::ClusterState clusval;
   clusval.mutable_uni_ls_state()->CopyFrom(curr);
   NNIGHierarchy cluster;
   cluster.set_state_from_proto(clusval);
@@ -32,13 +32,13 @@ TEST(write_proto, uni_ls) {
   curr.set_mean(mean);
   curr.set_var(var);
 
-  bayesmix::MarginalState::ClusterState clusval_in;
+  bayesmix::AlgorithmState::ClusterState clusval_in;
   clusval_in.mutable_uni_ls_state()->CopyFrom(curr);
   NNIGHierarchy cluster;
   cluster.set_state_from_proto(clusval_in);
 
-  bayesmix::MarginalState out;
-  bayesmix::MarginalState::ClusterState* clusval = out.add_cluster_states();
+  bayesmix::AlgorithmState out;
+  bayesmix::AlgorithmState::ClusterState* clusval = out.add_cluster_states();
   cluster.write_state_to_proto(clusval);
 
   double out_mean = clusval->uni_ls_state().mean();
@@ -60,7 +60,7 @@ TEST(set_state, multi_ls) {
   ASSERT_EQ(curr.prec().data(0), 1.0);
   ASSERT_EQ(curr.prec().data(6), 10.0);
 
-  bayesmix::MarginalState::ClusterState clusval_in;
+  bayesmix::AlgorithmState::ClusterState clusval_in;
   clusval_in.mutable_multi_ls_state()->CopyFrom(curr);
   NNWHierarchy cluster;
   cluster.set_state_from_proto(clusval_in);


### PR DESCRIPTION
So here's a draft I wrote yesterday. There's a few points of discussion:
* Conditional density estimation. If it is as easy as it sounds, we would just need to replace conditional cluster masses with mixing weights for the k-th iteration. If so, `eval_lpdf()` would be the exact same, and it may be worth to move it to the base class. We would only need to override `lpdf_from_state()`, as well as writing a new proto which also stores weights. This may or may not be the most challenging part, since we use a marginal proto everywhere in the library right now.
* ~`get_weights()` could use `log` and `propto` bools, just like the conditional cluster masses methods.~ EDIT: I already went and added them
* `sample_unique_values()` should just be the usual good old loop of `sample_full_cond()`. Should we do it only on nonempty hierarchies? If so, did we need to do the same in marginal algorithms?