### PR TITLE
Fixing Mixing

### DIFF
--- a/src/algorithms/marginal_algorithm.cc
+++ b/src/algorithms/marginal_algorithm.cc
@@ -1,6 +1,7 @@
 #include "marginal_algorithm.h"
 
 #include <Eigen/Dense>
+#include <cassert>
 #include <stan/math/prim/fun.hpp>
 
 #include "algorithm_state.pb.h"
@@ -11,6 +12,17 @@
 void MarginalAlgorithm::initialize() {
   BaseAlgorithm::initialize();
   marg_mixing = std::dynamic_pointer_cast<MarginalMixing>(mixing);
+}
+
+void MarginalAlgorithm::remove_singleton(const unsigned int idx) {
+  // Relabel allocations
+  for (auto &c : allocations) {
+    if (c > idx) {
+      c -= 1;
+    }
+  }
+  // Remove cluster
+  unique_values.erase(unique_values.begin() + idx);
 }
 
 Eigen::VectorXd MarginalAlgorithm::lpdf_from_state(
@@ -44,6 +56,7 @@ Eigen::VectorXd MarginalAlgorithm::lpdf_from_state(
         lpdf_marginal_component(temp_hier, grid.row(i), hier_covariate)(0);
     // Final estimate for i-th grid point
     lpdf_final(i) = stan::math::log_sum_exp(lpdf_local.row(i));
+    assert(!isnan(lpdf_final(i)));
   }
   return lpdf_final;
 }

--- a/src/algorithms/marginal_algorithm.h
+++ b/src/algorithms/marginal_algorithm.h
@@ -23,6 +23,8 @@ class MarginalAlgorithm : public BaseAlgorithm {
       const Eigen::RowVectorXd &mix_covariate) override;
   //!
   void initialize() override;
+  //!
+  void remove_singleton(const unsigned int idx);
 
  public:
   ~MarginalAlgorithm() = default;

--- a/src/mixings/dirichlet_mixing.cc
+++ b/src/mixings/dirichlet_mixing.cc
@@ -91,8 +91,9 @@ void DirichletMixing::update_state(
 void DirichletMixing::set_state_from_proto(
     const google::protobuf::Message &state_) {
   auto &statecast =
-      google::protobuf::internal::down_cast<const bayesmix::DPState &>(state_);
-  state.totalmass = statecast.totalmass();
+      google::protobuf::internal::down_cast<const bayesmix::MixingState &>(
+          state_);
+  state.totalmass = statecast.dp_state().totalmass();
   state.logtotmass = std::log(state.totalmass);
 }
 


### PR DESCRIPTION
So at first, I corrected the issue with empty clusters.
I then ran the algorithm checking if everything was fine, and I found ONE (***ONE***!!) iteration, among a total of 24000, which still had `nan`s. Luckily I decided not to dismiss it as computational issue, as I found another bug involving R/Wing states to proto, which I previously had fixed only for the DP Mixing. And basically, the density estimates were working with random/garbage state mixing values this whole time 🙃. I'm surprised the estimates still worked so well. Lucky us, they hit an invalid value just one time, and we could see the bug.
Honestly, fuck protos, they don't write stuff but they won't even tell you. I still don't fully understand why the old version doesn't work either, I'm like 99% sure I tested for it and it also makes perfect sense.

Please do check these lines in case I forgot anything.

Last thing: I noticed we never use `write_hypers_to_proto()` for Mixings. Should we delete it?