### PR TITLE
Grid methods

### DIFF
--- a/src/algorithms/marginal_algorithm.h
+++ b/src/algorithms/marginal_algorithm.h
@@ -13,7 +13,7 @@ class MarginalAlgorithm : public BaseAlgorithm {
   //! Computes marginal contribution of a given iteration & cluster
   virtual Eigen::VectorXd lpdf_marginal_component(
       std::shared_ptr<AbstractHierarchy> hier, const Eigen::MatrixXd &grid,
-      const Eigen::MatrixXd &covariates) const = 0;
+      const Eigen::RowVectorXd &covariate) const = 0;
   //!
   Eigen::VectorXd lpdf_from_state(
       const Eigen::MatrixXd &grid, const Eigen::RowVectorXd &hier_covariate,

--- a/src/algorithms/neal2_algorithm.cc
+++ b/src/algorithms/neal2_algorithm.cc
@@ -17,8 +17,8 @@
 //! \return     Vector of evaluation of component on the provided grid
 Eigen::VectorXd Neal2Algorithm::lpdf_marginal_component(
     std::shared_ptr<AbstractHierarchy> hier, const Eigen::MatrixXd &grid,
-    const Eigen::MatrixXd &covariates) const {
-  return hier->prior_pred_lpdf_grid(grid, covariates);
+    const Eigen::RowVectorXd &covariate) const {
+  return hier->prior_pred_lpdf_grid(grid, covariate);
 }
 
 Eigen::VectorXd Neal2Algorithm::get_cluster_prior_mass(

--- a/src/algorithms/neal2_algorithm.h
+++ b/src/algorithms/neal2_algorithm.h
@@ -33,7 +33,7 @@ class Neal2Algorithm : public MarginalAlgorithm {
   //! Computes marginal contribution of a given iteration & cluster
   Eigen::VectorXd lpdf_marginal_component(
       std::shared_ptr<AbstractHierarchy> hier, const Eigen::MatrixXd &grid,
-      const Eigen::MatrixXd &covariates) const override;
+      const Eigen::RowVectorXd &covariate) const override;
   //!
   virtual Eigen::VectorXd get_cluster_prior_mass(
       const unsigned int data_idx) const;

--- a/src/algorithms/neal8_algorithm.cc
+++ b/src/algorithms/neal8_algorithm.cc
@@ -17,13 +17,13 @@
 //! \return     Vector of evaluation of component on the provided grid
 Eigen::VectorXd Neal8Algorithm::lpdf_marginal_component(
     std::shared_ptr<AbstractHierarchy> hier, const Eigen::MatrixXd &grid,
-    const Eigen::MatrixXd &covariates) const {
+    const Eigen::RowVectorXd &covariate) const {
   unsigned int n_grid = grid.rows();
   Eigen::VectorXd lpdf_(n_grid);
   Eigen::MatrixXd lpdf_temp(n_grid, n_aux);
   for (size_t i = 0; i < n_aux; i++) {
     hier->sample_prior();
-    lpdf_temp.col(i) = hier->like_lpdf_grid(grid, covariates);
+    lpdf_temp.col(i) = hier->like_lpdf_grid(grid, covariate);
   }
   for (size_t i = 0; i < n_grid; i++) {
     lpdf_(i) = stan::math::log_sum_exp(lpdf_temp.row(i));

--- a/src/algorithms/neal8_algorithm.h
+++ b/src/algorithms/neal8_algorithm.h
@@ -34,7 +34,7 @@ class Neal8Algorithm : public Neal2Algorithm {
   //! Computes marginal contribution of a given iteration & cluster
   Eigen::VectorXd lpdf_marginal_component(
       std::shared_ptr<AbstractHierarchy> hier, const Eigen::MatrixXd &grid,
-      const Eigen::MatrixXd &covariates) const override;
+      const Eigen::RowVectorXd &covariate) const override;
   //!
   Eigen::VectorXd get_cluster_prior_mass(
       const unsigned int data_idx) const override;

--- a/src/hierarchies/base_hierarchy.h
+++ b/src/hierarchies/base_hierarchy.h
@@ -142,15 +142,22 @@ BaseHierarchy<Derived, State, Hyperparams, Prior>::like_lpdf_grid(
     const Eigen::MatrixXd &covariates /*= Eigen::MatrixXd(0, 0)*/) const {
   Eigen::VectorXd lpdf(data.rows());
   if (covariates.cols() == 0) {
+    // Pass null value as covariate
     for (int i = 0; i < data.rows(); i++) {
-      // Pass null value as covariate
       lpdf(i) = static_cast<Derived const *>(this)->like_lpdf(
           data.row(i), Eigen::RowVectorXd(0));
     }
-  } else {
+  } else if (covariates.rows() == 1) {
+    // Use unique covariate
     for (int i = 0; i < data.rows(); i++) {
       lpdf(i) = static_cast<Derived const *>(this)->like_lpdf(
           data.row(i), covariates.row(0));
+    }
+  } else {
+    // Use different covariates
+    for (int i = 0; i < data.rows(); i++) {
+      lpdf(i) = static_cast<Derived const *>(this)->like_lpdf(
+          data.row(i), covariates.row(i));
     }
   }
   return lpdf;
@@ -161,14 +168,24 @@ void BaseHierarchy<Derived, State, Hyperparams, Prior>::sample_full_cond(
     const Eigen::MatrixXd &data,
     const Eigen::MatrixXd &covariates /*= Eigen::MatrixXd(0, 0)*/) {
   static_cast<Derived *>(this)->clear_data();
-  if (covariates == Eigen::MatrixXd(0, 0)) {
-    for (int i = 0; i < data.rows(); i++)
+  if (covariates.cols() == 0) {
+    // Pass null value as covariate
+    for (int i = 0; i < data.rows(); i++) {
       static_cast<Derived *>(this)->add_datum(i, data.row(i), false,
                                               Eigen::RowVectorXd(0));
+    }
+  } else if (covariates.rows() == 1) {
+    // Use unique covariate
+    for (int i = 0; i < data.rows(); i++) {
+      static_cast<Derived *>(this)->add_datum(i, data.row(i), false,
+                                              covariates.row(0));
+    }
   } else {
-    for (int i = 0; i < data.rows(); i++)
+    // Use different covariates
+    for (int i = 0; i < data.rows(); i++) {
       static_cast<Derived *>(this)->add_datum(i, data.row(i), false,
                                               covariates.row(i));
+    }
   }
   static_cast<Derived *>(this)->sample_full_cond(true);
 }

--- a/src/hierarchies/conjugate_hierarchy.h
+++ b/src/hierarchies/conjugate_hierarchy.h
@@ -67,15 +67,22 @@ ConjugateHierarchy<Derived, State, Hyperparams, Prior>::prior_pred_lpdf_grid(
     const Eigen::MatrixXd &covariates /*= Eigen::MatrixXd(0, 0)*/) const {
   Eigen::VectorXd lpdf(data.rows());
   if (covariates.cols() == 0) {
+    // Pass null value as covariate
     for (int i = 0; i < data.rows(); i++) {
-      // Pass null value as covariate
       lpdf(i) = static_cast<Derived const *>(this)->prior_pred_lpdf(
           data.row(i), Eigen::RowVectorXd(0));
     }
-  } else {
+  } else if (covariates.rows() == 1) {
+    // Use unique covariate
     for (int i = 0; i < data.rows(); i++) {
       lpdf(i) = static_cast<Derived const *>(this)->prior_pred_lpdf(
           data.row(i), covariates.row(0));
+    }
+  } else {
+    // Use different covariates
+    for (int i = 0; i < data.rows(); i++) {
+      lpdf(i) = static_cast<Derived const *>(this)->prior_pred_lpdf(
+          data.row(i), covariates.row(i));
     }
   }
   return lpdf;
@@ -88,15 +95,22 @@ Eigen::VectorXd ConjugateHierarchy<Derived, State, Hyperparams, Prior>::
         const Eigen::MatrixXd &covariates /*= Eigen::MatrixXd(0, 0)*/) const {
   Eigen::VectorXd lpdf(data.rows());
   if (covariates.cols() == 0) {
+    // Pass null value as covariate
     for (int i = 0; i < data.rows(); i++) {
-      // Pass null value as covariate
       lpdf(i) = static_cast<Derived const *>(this)->conditional_pred_lpdf(
           data.row(i), Eigen::RowVectorXd(0));
     }
-  } else {
+  } else if (covariates.rows() == 1) {
+    // Use unique covariate
     for (int i = 0; i < data.rows(); i++) {
       lpdf(i) = static_cast<Derived const *>(this)->conditional_pred_lpdf(
           data.row(i), covariates.row(0));
+    }
+  } else {
+    // Use different covariates
+    for (int i = 0; i < data.rows(); i++) {
+      lpdf(i) = static_cast<Derived const *>(this)->conditional_pred_lpdf(
+          data.row(i), covariates.row(i));
     }
   }
   return lpdf;


### PR DESCRIPTION
A quick fix to hierarchy grid methods, which I mentioned in #71. I figured it would be best to allow both the case with a single covariate and with different ones, in case the latter is ever needed.

I had forgot that we also use grid methods in the algorithms, specifically in `lpdf_marginal_component()` in density evaluation, which still accepted a covariate grid.

I have tested all main algorithms and they run fine. Please let me know if I broke something down in the SHDP sampler.
