### PR TITLE
Small corrections + README updates

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,4 +1,4 @@
-# Contributors of bayesmix
+# Contributors of `bayesmix`
 ## Recommendations
 Before commiting anything, please install the pre-commit hooks by running
 ```shell
@@ -6,14 +6,26 @@ Before commiting anything, please install the pre-commit hooks by running
 ```
 This automatically clears the output of all Jupyter notebooks, if necessary.
 
+
 ## Style
 This library follows the official [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html).
-You can install the `clang-format` package to allow automatic formatting adjustment of any file.
-You can do so by running
+This includes using the `.cc` extension for source files and `.h` for header files, not `.cpp` or `.hpp`.
+
+You can install the `clang-format` package to allow automatic formatting adjustment of any file, for instance by running:
 ```shell
-clang-format -i --style=file yourfile.cc
+sudo apt-get install clang-format
+```
+Finally, you can use the package to format files appropriately with:
+```shell
+clang-format -i --style=file yourfile1.h yourfile2.cc
 ```
 which reads the appropriate settings from the ```.clang-format``` file at the root folder.
+You can also use wildcards to include multiple files at once.
+For example, the following command will read all files in the `src/hierarchies` subfolder which end in `.h`:
+```shell
+clang-format -i --style=file src/hierarchies/*.h
+```
+
 
 ## Future steps
 * Extension to normalized random measures
@@ -21,6 +33,7 @@ which reads the appropriate settings from the ```.clang-format``` file at the ro
 * R package
 * Please check out the [issue page](https://github.com/bayesmix-dev/bayesmix/issues) for more planned enhancements.
 
-## Hierarchies
+
+## A note on Hierarchies and Mixings
 This library implements `Hierarchy` and `Mixing` objects through the [Curiously Recurring Template Pattern](https://en.wikipedia.org/wiki/Curiously_recurring_template_pattern).
 Please check out [src/hierarchies/README.md](src/hierarchies/README.md) for more details.

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ make check
 sudo make install
 sudo ldconfig
 ```
-On Mac and Windows machines, please follow the official `protobuf` installation guide ([link](https://github.com/protocolbuffers/protobuf/blob/master/src/README.md)) instead.
+On Mac and Windows machines, please follow the [official `protobuf` installation guide](https://github.com/protocolbuffers/protobuf/blob/master/src/README.md) instead.
 
 Another very useful tool is [`ccache`](https://ccache.dev) that can significantly speed up the compilation process.
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ To perform your first run of the library right out of the box, you can call the 
 example/tutorial/run.sh
 ```
 This is an example script that runs said executable by passing appropriate arguments to it.
-In order to use your custom datasets, algorithm settings, and prior specifications, please create a copy of the above script and change the arguments as appropriate.
+In order to use your custom datasets, algorithm settings, and prior specifications, you can create a copy of the above script and change the arguments as appropriate.
+Please refer to the [documentation](#Documentation) for more information.
 
 
 ## For developers

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Documentation Status](https://readthedocs.org/projects/bayesmix/badge/?version=latest)](https://bayesmix.readthedocs.io/en/latest/?badge=latest)
 
-`bayesmix` is a C++ library for running MCMC simulation in Bayesian mixture models.
+`bayesmix` is a C++ library for running MCMC simulations in Bayesian mixture models.
 
 Current state of the software:
 - `bayesmix` performs inference for mixture models of the kind
@@ -11,27 +11,26 @@ Current state of the software:
 
 <a href="https://www.codecogs.com/eqnedit.php?latex=P&space;\sim&space;\Pi" target="_blank"><img src="https://latex.codecogs.com/gif.latex?P&space;\sim&space;\Pi" title="\Pi \sim P" /></a>
 
-Where P is either the Dirichlet process or the Pitman--Yor process.
+where P is either the Dirichlet process or the Pitman--Yor process
 
 - We currently support univariate and multivariate location-scale mixture of Gaussian densities
 
-- Inference is carried out using either Algorithm 2 or Algorithm 8 in [Neal (2000)](http://www.stat.columbia.edu/npbayes/papers/neal_sampling.pdf).
+- Inference is carried out using algorithms such as Algorithm 2 in [Neal (2000)](http://www.stat.columbia.edu/npbayes/papers/neal_sampling.pdf)
 
-- Serialization of the MCMC chains is possible using [Google's protocol buffers](https://developers.google.com/protocol-buffers)
+- Serialization of the MCMC chains is possible using Google's Protocol Buffers](https://developers.google.com/protocol-buffers), aka `protobuf`
 
 
-## Installation
 
-### For end users
+# Installation
+## For end users
+**Warning**: make sure you have a recent version of `cmake` installed (at least 3.20.x) or install `protobuf` beforehand (see the section for developers)!
 
-!!! Make sure you have a recent version of cmake installed (at least 3.20.x) or install protobuf beforehand (see the section for developers)
-
-Just clone the repository with
+To install and use `bayesmix`, please clone this repository with the following command-line instruction:
 ```shell
 git clone --recurse-submodule git@github.com:bayesmix-dev/bayesmix.git
 ```
 
-To run the executable:
+To build the executable for the main file `run.cc`, please use the following list of commands:
 ```shell
 mkdir build
 cd build
@@ -40,15 +39,17 @@ make run
 cd ..
 ```
 
-The executable `./build/run` can be used to perform all the necessary analysis. See the file `bash/run_test.sh` for examples of usage with command line arguments.
+### Tutorial
+The `build/run` executable can be used to perform all the necessary analysis, but it needs some command-line arguments to be passed.
+An example script that runs said executable by passing appropriate arguments to it is `example/tutorial/run.sh`, which you can run right out of the box from your command line to perform a first run of the library.
+In order to use your custom datasets, algorithm settings, and prior specifications, please create a copy of the above script and change the arguments as appropriate.
 
 
-### For developers
-
-
-We heavily depend on Google's [Protocol Buffers](https://github.com/protocolbuffers/protobuf). The CMakeLists.txt file is set up to install the library if it does not find it in the computer. However any call to `make clean` will uninstall it, causing a huge waste of time... so make sure to install it beforehand!
-
-On Linux machine the following will install the library
+## For developers
+We heavily depend on the `protobuf` library to move and store structured data.
+The `CMakeLists.txt` file is set up to install such library if it does not find it in the computer.
+However any call to `make clean` will uninstall it, causing a huge waste of time... so make sure to install it manually beforehand!
+You can do so as follows on a Linux machine:
 ```shell
 sudo apt-get install autoconf automake libtool curl make g++ unzip cmake
 wget https://github.com/protocolbuffers/protobuf/releases/download/v3.14.0/protobuf-python-3.14.0.zip
@@ -57,36 +58,23 @@ cd protobuf-3.14.0/
 ./configure --prefix=/usr
 make check
 sudo make install
-sudo ldconfig # refresh shared library cache.
+sudo ldconfig
 ```
-On Mac and Windows machines, follow the official install guide ([link](https://github.com/protocolbuffers/protobuf/blob/master/src/README.md))
+On Mac and Windows machines, please follow the official `protobuf` installation guide ([link](https://github.com/protocolbuffers/protobuf/blob/master/src/README.md)) instead.
 
-Another very useful tool is [`ccache`](https://ccache.dev) that significantly speed up the compilation.
+Another very useful tool is [`ccache`](https://ccache.dev) that can significantly speed up the compilation process.
 
-Finally, to work with `bayesmix`, just clone the repository with
-```shell
-git clone --recurse-submodule git@github.com:bayesmix-dev/bayesmix.git
-```
-
-To run the executable:
-```shell
-mkdir build
-cd build
-cmake ..
-make run
-cd ..
-```
-
-To run unit tests:
+Finally, to compile unit tests, please use the following commands:
 ```shell
 cd build
 cmake ..
 make test_bayesmix
-./test/test_bayesmix
+cd ..
 ```
+The corresponding executable is located at `build/test/test_bayesmix`.
 
-## Documentation
+# Documentation
 Documentation is available at https://bayesmix.readthedocs.io.
 
-## Contributions are welcome!
+# Contributions are welcome!
 Please check out [CONTRIBUTORS.md](CONTRIBUTORS.md) for details on how to collaborate with us.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,11 @@ cd ..
 
 ### Tutorial
 The `build/run` executable can be used to perform all the necessary analysis, but it needs some command-line arguments to be passed.
-An example script that runs said executable by passing appropriate arguments to it is `example/tutorial/run.sh`, which you can run right out of the box from your command line to perform a first run of the library.
+To perform your first run of the library right out of the box, you can call the following script from the command line:
+```shell
+example/tutorial/run.sh
+```
+This is an example script that runs said executable by passing appropriate arguments to it.
 In order to use your custom datasets, algorithm settings, and prior specifications, please create a copy of the above script and change the arguments as appropriate.
 
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ In order to use your custom datasets, algorithm settings, and prior specificatio
 We heavily depend on the `protobuf` library to move and store structured data.
 The `CMakeLists.txt` file is set up to install such library if it does not find it in the computer.
 However any call to `make clean` will uninstall it, causing a huge waste of time... so make sure to install it manually beforehand!
-You can do so as follows on a Linux machine:
+If you're using a Linux machine, you can do so as follows:
 ```shell
 sudo apt-get install autoconf automake libtool curl make g++ unzip cmake
 wget https://github.com/protocolbuffers/protobuf/releases/download/v3.14.0/protobuf-python-3.14.0.zip
@@ -64,7 +64,7 @@ make check
 sudo make install
 sudo ldconfig
 ```
-On Mac and Windows machines, please follow the [official `protobuf` installation guide](https://github.com/protocolbuffers/protobuf/blob/master/src/README.md) instead.
+On Mac and Windows machines, please follow the steps from the [official `protobuf` installation guide](https://github.com/protocolbuffers/protobuf/blob/master/src/README.md).
 
 Another very useful tool is [`ccache`](https://ccache.dev) that can significantly speed up the compilation process.
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ cd ..
 The `build/run` executable can be used to perform all the necessary analysis, but it needs some command-line arguments to be passed.
 To perform your first run of the library right out of the box, you can call the following script from the command line:
 ```shell
-example/tutorial/run.sh
+examples/tutorial/run.sh
 ```
 This is an example script that runs said executable by passing appropriate arguments to it.
 In order to use your custom datasets, algorithm settings, and prior specifications, you can create a copy of the above script and change the arguments as appropriate.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ where P is either the Dirichlet process or the Pitman--Yor process
 
 - Inference is carried out using algorithms such as Algorithm 2 in [Neal (2000)](http://www.stat.columbia.edu/npbayes/papers/neal_sampling.pdf)
 
-- Serialization of the MCMC chains is possible using Google's Protocol Buffers](https://developers.google.com/protocol-buffers), aka `protobuf`
+- Serialization of the MCMC chains is possible using Google's [Protocol Buffers](https://developers.google.com/protocol-buffers) aka `protobuf`
 
 
 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -3,7 +3,7 @@ bayesmix/utils
 Tutorial - Univariate data
 ==========================
 
-You can run the ``bash/tutorial.sh`` script for a quick example on how to use the ``run.cc`` file.
+You can run the ``examples/tutorial/run.sh`` script for a quick example on how to use the ``run.cc`` file.
 This example uses files which are available in the ``resources/tutorial`` subfolder.
 We recommend that you open and read these files for a better understanding of how the process works.
 The aforementioned script executes the following command:

--- a/examples/gamma_hierarchy/gamma_gamma_hier.h
+++ b/examples/gamma_hierarchy/gamma_gamma_hier.h
@@ -64,7 +64,7 @@ class GammaGammaHierarchy
   }
 
   //! Computes and return posterior hypers given data currently in this cluster
-  GammaGamma::Hyperparams get_posterior_parameters() {
+  GammaGamma::Hyperparams compute_posterior_hypers() {
     GammaGamma::Hyperparams out;
     out.shape = hypers->shape;
     out.rate_alpha = hypers->rate_alpha + hypers->shape * ndata;

--- a/src/hierarchies/README.md
+++ b/src/hierarchies/README.md
@@ -70,7 +70,7 @@ Instead, child classes must implement:
 6. `initialize_state`: initializes the current theta_h given the hyperparameters in P_0
 7. `initialize_hypers`: initializes the hyperparameters in P_0 given their hyperprior
 8. `update_summary_statistics`: updates the summary statistics when an observation is allocated or de-allocated from the hierarchy
-9. `get_posterior_parameters`: returns the paramters of the full conditional distribution, which is **only possible when P_0 and k are conjugate**
+9. `compute_posterior_hypers`: returns the paramters of the full conditional distribution, which is **only possible when P_0 and k are conjugate**
 10. `set_state_from_proto`
 11. `write_state_to_proto`
 12. `write_hypers_to_proto`

--- a/src/hierarchies/README.md
+++ b/src/hierarchies/README.md
@@ -10,8 +10,7 @@ coupled with a prior on the parameters:
 <a href="https://www.codecogs.com/eqnedit.php?latex=\theta_i&space;\sim&space;P_0" target="_blank"><img src="https://latex.codecogs.com/gif.latex?\theta_i&space;\sim&space;P_0" title="\theta_i \sim P_0" /></a>
 
 the two quantities k (i.e. the component 'likelihood')  and P_0 define what we call a 'hierarchy'.
-In our code, we use the terms 'hierarchy', 'unique value' and 'cluster' interchangeably 
-when referring to the hierarchies.
+In our code, we use the terms 'hierarchy', 'unique value' and 'cluster' interchangeably when referring to the hierarchies.
 
 This is a basic building block of all MCMC algorithms form mixture models. Moreover, P_0 and k cannot be handled separately, since the update of parameters theta_h depends on both k and P_0.
 
@@ -27,7 +26,7 @@ The hierarchy implements all the methods needed to update theta_h: sampling from
 
 ## Main operations performed
 
-Given what we said, a hierarchy must be able to perform the following operations
+Therefore, a hierarchy must be able to perform the following operations
 
 1. Sample from the prior distribution: generate theta_h ~ P_0 [`sample_prior`]
 2. Sample from the 'full conditional' distribution: generate theta_h from the distribution 
@@ -57,22 +56,21 @@ Finally, the update involeved in the full_conditional, especially if P_0 and k a
 We employ a Curiously Recurring Template Pattern coupled with an abstract interface. 
 The code thus composes of: a virtual class defining the API, a template base class that is the base for the CRTP and derived child classes that fully specialize the template arguments.
 
-The class `AbstractHierarchy` defines the API, i.e. all the methods that need to be called 
-from outside of a Hierarchy class. 
+The class `AbstractHierarchy` defines the API, i.e. all the methods that need to be called from outside of a Hierarchy class.
 A template class `BaseHierarchy` inherits from `AbstractHierarchy` and implements some of the virtual methods in in, specifically: `sample_prior`, `sample_full_cond`, `initialize`, `add_datum`, `remove_datum`, `prior_pred_lpdf`, `conditional_pred_ldpf` `get_mutable_prior`, `like_lpdf_grid`, `prior_pred_lpdf_grid` and `conditional_pred_lpdf_grid`.
 These methods do not need to be implemented by the child classes. 
 
 Instead, child classes must implement:
 
-1. `like_lpdf`: evaluates k(x | theta_h)
+1. `like_lpdf`: evaluates k(x \| theta_h)
 2. `marg_lpdf`: evaluates m(x) given some parameters theta_h (could be both the hyperparameters in P_0 or the paramters given by the full conditionals)
 3. `draw`: samples from P_0 given the parameters
-4. `clear_summary_statistics`: clears all the summary statistics
+4. `clear_summary_statistics`
 5. `update_hypers`: performs the update of parameters in P_0 given all the theta_h's (passed as a vector of protobuf Messages)
 6. `initialize_state`: initializes the current theta_h given the hyperparameters in P_0
 7. `initialize_hypers`: initializes the hyperparameters in P_0 given their hyperprior
 8. `update_summary_statistics`: updates the summary statistics when an observation is allocated or de-allocated from the hierarchy
-9. `get_posterior_parameters`: returns the paramters of the full conditional distribution **possible only when P_0 and k are conjugate**
+9. `get_posterior_parameters`: returns the paramters of the full conditional distribution, which is **only possible when P_0 and k are conjugate**
 10. `set_state_from_proto`
 11. `write_state_to_proto`
 12. `write_hypers_to_proto`
@@ -85,5 +83,4 @@ The BaseHierarchy class takes 4 template parameters:
 3. `Hyperparams` is usually a struct representing the parameters in P_0
 4. `Prior` must be a protobuf object encoding the prior parameters.
 
-Finally, a ConjugateHierarchy takes care of the implementation of some methods that are specific to conjugate models.
-
+Finally, a `ConjugateHierarchy` takes care of the implementation of some methods that are specific to conjugate models.

--- a/src/hierarchies/abstract_hierarchy.h
+++ b/src/hierarchies/abstract_hierarchy.h
@@ -137,6 +137,9 @@ class AbstractHierarchy {
       const std::vector<bayesmix::AlgorithmState::ClusterState> &states) = 0;
 
   // GETTERS AND SETTERS
+  //! Returns the Protobuf ID associated to this class
+  virtual bayesmix::HierarchyId get_id() const = 0;
+
   //! Returns the current cardinality of the cluster
   virtual int get_card() const = 0;
 
@@ -192,16 +195,7 @@ class AbstractHierarchy {
   //! Main function that initializes members to appropriate values
   virtual void initialize() = 0;
 
-  //! Initializes state parameters to appropriate values
-  virtual void initialize_state() = 0;
-
-  //! Initializes hierarchy hyperparameters to appropriate values
-  virtual void initialize_hypers() = 0;
-
-  //! Raises an error if the prior pointer is not initialized
-  virtual void check_prior_is_set() const = 0;
-
-  // FEATURES AND IDENTIFIERS
+  // HIERARCHY FEATURES
   //! Returns whether the hierarchy models multivariate data or not
   virtual bool is_multivariate() const = 0;
 
@@ -210,9 +204,6 @@ class AbstractHierarchy {
 
   //! Returns whether the hierarchy represents a conjugate model or not
   virtual bool is_conjugate() const { return false; }
-
-  //! Returns the Protobuf ID associated to this class
-  virtual bayesmix::HierarchyId get_id() const = 0;
 
  protected:
   //! Evaluates the log-likelihood of data in a single point
@@ -272,8 +263,20 @@ class AbstractHierarchy {
   //! Sets the cluster's cardinality
   virtual void set_card(const int card_) = 0;
 
-  //! Removes all indicators of data points belonging to this cluster
+  //! Resets cardinality and data indexes of data in this cluster
   virtual void clear_data() = 0;
+
+  //! Resets summary statistics for this cluster
+  virtual void clear_summary_statistics() = 0;
+
+  //! Initializes state parameters to appropriate values
+  virtual void initialize_state() = 0;
+
+  //! Initializes hierarchy hyperparameters to appropriate values
+  virtual void initialize_hypers() = 0;
+
+  //! Raises an error if the prior pointer is not initialized
+  virtual void check_prior_is_set() const = 0;
 
   //! Re-initializes the prior of the hierarchy to a newly created object
   virtual void create_empty_prior() = 0;

--- a/src/hierarchies/abstract_hierarchy.h
+++ b/src/hierarchies/abstract_hierarchy.h
@@ -275,6 +275,9 @@ class AbstractHierarchy {
   //! Removes all indicators of data points belonging to this cluster
   virtual void clear_data() = 0;
 
+  //! Re-initializes the prior of the hierarchy to a newly created object
+  virtual void create_empty_prior() = 0;
+
   //! Down-casts the given generic proto message to a ClusterState proto
   virtual bayesmix::AlgorithmState::ClusterState *downcast_state(
       google::protobuf::Message *state_) const = 0;

--- a/src/hierarchies/abstract_hierarchy.h
+++ b/src/hierarchies/abstract_hierarchy.h
@@ -198,6 +198,9 @@ class AbstractHierarchy {
   //! Initializes hierarchy hyperparameters to appropriate values
   virtual void initialize_hypers() = 0;
 
+  //! Raises an error if the prior pointer is not initialized
+  virtual void check_prior_is_set() const = 0;
+
   // FEATURES AND IDENTIFIERS
   //! Returns whether the hierarchy models multivariate data or not
   virtual bool is_multivariate() const = 0;
@@ -265,6 +268,20 @@ class AbstractHierarchy {
       throw std::runtime_error("Not implemented");
     }
   }
+
+  //! Sets the cluster's cardinality
+  virtual void set_card(const int card_) = 0;
+
+  //! Removes all indicators of data points belonging to this cluster
+  virtual void clear_data() = 0;
+
+  //! Down-casts the given generic proto message to a ClusterState proto
+  virtual bayesmix::AlgorithmState::ClusterState *downcast_state(
+      google::protobuf::Message *state_) const = 0;
+
+  //! Down-casts the given generic proto message to a ClusterState proto
+  virtual const bayesmix::AlgorithmState::ClusterState &downcast_state(
+      const google::protobuf::Message &state_) const = 0;
 };
 
 #endif  // BAYESMIX_HIERARCHIES_ABSTRACT_HIERARCHY_H_

--- a/src/hierarchies/abstract_hierarchy.h
+++ b/src/hierarchies/abstract_hierarchy.h
@@ -260,12 +260,6 @@ class AbstractHierarchy {
     }
   }
 
-  //! Sets the cluster's cardinality
-  virtual void set_card(const int card_) = 0;
-
-  //! Resets cardinality and data indexes of data in this cluster
-  virtual void clear_data() = 0;
-
   //! Resets summary statistics for this cluster
   virtual void clear_summary_statistics() = 0;
 
@@ -274,20 +268,6 @@ class AbstractHierarchy {
 
   //! Initializes hierarchy hyperparameters to appropriate values
   virtual void initialize_hypers() = 0;
-
-  //! Raises an error if the prior pointer is not initialized
-  virtual void check_prior_is_set() const = 0;
-
-  //! Re-initializes the prior of the hierarchy to a newly created object
-  virtual void create_empty_prior() = 0;
-
-  //! Down-casts the given generic proto message to a ClusterState proto
-  virtual bayesmix::AlgorithmState::ClusterState *downcast_state(
-      google::protobuf::Message *state_) const = 0;
-
-  //! Down-casts the given generic proto message to a ClusterState proto
-  virtual const bayesmix::AlgorithmState::ClusterState &downcast_state(
-      const google::protobuf::Message &state_) const = 0;
 };
 
 #endif  // BAYESMIX_HIERARCHIES_ABSTRACT_HIERARCHY_H_

--- a/src/hierarchies/abstract_hierarchy.h
+++ b/src/hierarchies/abstract_hierarchy.h
@@ -259,15 +259,6 @@ class AbstractHierarchy {
       throw std::runtime_error("Not implemented");
     }
   }
-
-  //! Resets summary statistics for this cluster
-  virtual void clear_summary_statistics() = 0;
-
-  //! Initializes state parameters to appropriate values
-  virtual void initialize_state() = 0;
-
-  //! Initializes hierarchy hyperparameters to appropriate values
-  virtual void initialize_hypers() = 0;
 };
 
 #endif  // BAYESMIX_HIERARCHIES_ABSTRACT_HIERARCHY_H_

--- a/src/hierarchies/abstract_hierarchy.h
+++ b/src/hierarchies/abstract_hierarchy.h
@@ -155,12 +155,6 @@ class AbstractHierarchy {
   //! Writes current state to a Protobuf message by pointer
   virtual void write_state_to_proto(google::protobuf::Message *out) const = 0;
 
-  //! Writes current state to a Protobuf message and return a shared_ptr
-  //! New hierarchies have to first modify the field 'oneof val' in the
-  //! AlgoritmState::ClusterState message by adding the appropriate type
-  virtual std::shared_ptr<bayesmix::AlgorithmState::ClusterState>
-  get_state_proto() const = 0;
-
   //! Writes current hyperparameters to a Protobuf message by pointer
   virtual void write_hypers_to_proto(google::protobuf::Message *out) const = 0;
 

--- a/src/hierarchies/base_hierarchy.h
+++ b/src/hierarchies/base_hierarchy.h
@@ -132,6 +132,12 @@ class BaseHierarchy : public AbstractHierarchy {
     log_card = (card_ == 0) ? stan::math::NEGATIVE_INFTY : std::log(card_);
   }
 
+  //! Writes current state to a Protobuf message and return a shared_ptr
+  //! New hierarchies have to first modify the field 'oneof val' in the
+  //! AlgoritmState::ClusterState message by adding the appropriate type
+  virtual std::shared_ptr<bayesmix::AlgorithmState::ClusterState>
+  get_state_proto() const = 0;
+
   //! Initializes state parameters to appropriate values
   virtual void initialize_state() = 0;
 

--- a/src/hierarchies/base_hierarchy.h
+++ b/src/hierarchies/base_hierarchy.h
@@ -108,11 +108,11 @@ class BaseHierarchy : public AbstractHierarchy {
   void initialize() override {
     hypers = std::make_shared<Hyperparams>();
     check_prior_is_set();
-    initialize_hypers();
-    initialize_state();
+    static_cast<Derived *>(this)->initialize_hypers();
+    static_cast<Derived *>(this)->initialize_state();
     posterior_hypers = *hypers;
     clear_data();
-    clear_summary_statistics();
+    static_cast<Derived *>(this)->clear_summary_statistics();
   }
 
  protected:

--- a/src/hierarchies/base_hierarchy.h
+++ b/src/hierarchies/base_hierarchy.h
@@ -125,16 +125,15 @@ class BaseHierarchy : public AbstractHierarchy {
   //! Re-initializes the prior of the hierarchy to a newly created object
   void create_empty_prior() override { prior.reset(new Prior); }
 
-  //! Sets the cluster's cardinality
+  //! Sets the cardinality of the cluster
   void set_card(const int card_) override {
     card = card_;
-    log_card = std::log(card_);
+    log_card = (card_ == 0) ? stan::math::NEGATIVE_INFTY : std::log(card_);
   }
 
   //! Removes all indicators of data points belonging to this cluster
   void clear_data() override {
-    card = 0;
-    // TODO log_card?
+    set_card(0);
     cluster_data_idx = std::set<int>();
   }
 
@@ -195,8 +194,7 @@ void BaseHierarchy<Derived, State, Hyperparams, Prior>::remove_datum(
     const bool update_params /*= false*/,
     const Eigen::RowVectorXd &covariate /* = Eigen::RowVectorXd(0)*/) {
   static_cast<Derived *>(this)->update_ss(datum, covariate, false);
-  card -= 1;
-  log_card = (card == 0) ? stan::math::NEGATIVE_INFTY : std::log(card);
+  set_card(card - 1);
   auto it = cluster_data_idx.find(id);
   assert(it != cluster_data_idx.end());
   cluster_data_idx.erase(it);

--- a/src/hierarchies/base_hierarchy.h
+++ b/src/hierarchies/base_hierarchy.h
@@ -107,13 +107,14 @@ class BaseHierarchy : public AbstractHierarchy {
   void initialize() override {
     hypers = std::make_shared<Hyperparams>();
     check_prior_is_set();
-    static_cast<Derived *>(this)->initialize_hypers();
-    static_cast<Derived *>(this)->initialize_state();
+    initialize_hypers();
+    initialize_state();
     posterior_hypers = *hypers;
-    static_cast<Derived *>(this)->clear_data();
-    static_cast<Derived *>(this)->clear_summary_statistics();
+    clear_data();
+    clear_summary_statistics();
   }
 
+ protected:
   //! Raises an error if the prior pointer is not initialized
   void check_prior_is_set() const override {
     if (prior == nullptr) {
@@ -121,7 +122,6 @@ class BaseHierarchy : public AbstractHierarchy {
     }
   }
 
- protected:
   //! Re-initializes the prior of the hierarchy to a newly created object
   void create_empty_prior() override { prior.reset(new Prior); }
 
@@ -131,7 +131,7 @@ class BaseHierarchy : public AbstractHierarchy {
     log_card = (card_ == 0) ? stan::math::NEGATIVE_INFTY : std::log(card_);
   }
 
-  //! Removes all indicators of data points belonging to this cluster
+  //! Resets cardinality and data indexes of data in this cluster
   void clear_data() override {
     set_card(0);
     cluster_data_idx = std::set<int>();

--- a/src/hierarchies/base_hierarchy.h
+++ b/src/hierarchies/base_hierarchy.h
@@ -108,11 +108,11 @@ class BaseHierarchy : public AbstractHierarchy {
   void initialize() override {
     hypers = std::make_shared<Hyperparams>();
     check_prior_is_set();
-    static_cast<Derived *>(this)->initialize_hypers();
-    static_cast<Derived *>(this)->initialize_state();
+    initialize_hypers();
+    initialize_state();
     posterior_hypers = *hypers;
     clear_data();
-    static_cast<Derived *>(this)->clear_summary_statistics();
+    clear_summary_statistics();
   }
 
  protected:
@@ -132,11 +132,19 @@ class BaseHierarchy : public AbstractHierarchy {
     log_card = (card_ == 0) ? stan::math::NEGATIVE_INFTY : std::log(card_);
   }
 
+  //! Initializes state parameters to appropriate values
+  virtual void initialize_state() = 0;
+
+  //! Initializes hierarchy hyperparameters to appropriate values
+  virtual void initialize_hypers() = 0;
+
   //! Resets cardinality and indexes of data in this cluster
   void clear_data() {
     set_card(0);
     cluster_data_idx = std::set<int>();
   }
+
+  virtual void clear_summary_statistics() = 0;
 
   //! Down-casts the given generic proto message to a ClusterState proto
   bayesmix::AlgorithmState::ClusterState *downcast_state(
@@ -247,8 +255,8 @@ template <class Derived, typename State, typename Hyperparams, typename Prior>
 void BaseHierarchy<Derived, State, Hyperparams, Prior>::sample_full_cond(
     const Eigen::MatrixXd &data,
     const Eigen::MatrixXd &covariates /*= Eigen::MatrixXd(0, 0)*/) {
-  static_cast<Derived *>(this)->clear_data();
-  static_cast<Derived *>(this)->clear_summary_statistics();
+  clear_data();
+  clear_summary_statistics();
   if (covariates.cols() == 0) {
     // Pass null value as covariate
     for (int i = 0; i < data.rows(); i++) {

--- a/src/hierarchies/base_hierarchy.h
+++ b/src/hierarchies/base_hierarchy.h
@@ -56,7 +56,7 @@ class BaseHierarchy : public AbstractHierarchy {
   //! Generates new state values from the centering prior distribution
   void sample_prior() override {
     state = static_cast<Derived *>(this)->draw(*hypers);
-  };
+  }
 
   //! Overloaded version of sample_full_cond(bool), mainly used for debugging
   virtual void sample_full_cond(

--- a/src/hierarchies/base_hierarchy.h
+++ b/src/hierarchies/base_hierarchy.h
@@ -74,8 +74,9 @@ class BaseHierarchy : public AbstractHierarchy {
 
   //! Returns a pointer to the Protobuf message of the prior of this cluster
   virtual google::protobuf::Message *get_mutable_prior() override {
-    if (prior == nullptr) create_empty_prior();
-
+    if (prior == nullptr) {
+      create_empty_prior();
+    }
     return prior.get();
   }
 
@@ -116,37 +117,37 @@ class BaseHierarchy : public AbstractHierarchy {
 
  protected:
   //! Raises an error if the prior pointer is not initialized
-  void check_prior_is_set() const override {
+  void check_prior_is_set() const {
     if (prior == nullptr) {
       throw std::invalid_argument("Hierarchy prior was not provided");
     }
   }
 
   //! Re-initializes the prior of the hierarchy to a newly created object
-  void create_empty_prior() override { prior.reset(new Prior); }
+  void create_empty_prior() { prior.reset(new Prior); }
 
   //! Sets the cardinality of the cluster
-  void set_card(const int card_) override {
+  void set_card(const int card_) {
     card = card_;
     log_card = (card_ == 0) ? stan::math::NEGATIVE_INFTY : std::log(card_);
   }
 
-  //! Resets cardinality and data indexes of data in this cluster
-  void clear_data() override {
+  //! Resets cardinality and indexes of data in this cluster
+  void clear_data() {
     set_card(0);
     cluster_data_idx = std::set<int>();
   }
 
   //! Down-casts the given generic proto message to a ClusterState proto
   bayesmix::AlgorithmState::ClusterState *downcast_state(
-      google::protobuf::Message *state_) const override {
+      google::protobuf::Message *state_) const {
     return google::protobuf::internal::down_cast<
         bayesmix::AlgorithmState::ClusterState *>(state_);
   }
 
   //! Down-casts the given generic proto message to a ClusterState proto
   const bayesmix::AlgorithmState::ClusterState &downcast_state(
-      const google::protobuf::Message &state_) const override {
+      const google::protobuf::Message &state_) const {
     return google::protobuf::internal::down_cast<
         const bayesmix::AlgorithmState::ClusterState &>(state_);
   }

--- a/src/hierarchies/base_hierarchy.h
+++ b/src/hierarchies/base_hierarchy.h
@@ -115,7 +115,7 @@ class BaseHierarchy : public AbstractHierarchy {
   }
 
   //! Raises an error if the prior pointer is not initialized
-  void check_prior_is_set() const {
+  void check_prior_is_set() const override {
     if (prior == nullptr) {
       throw std::invalid_argument("Hierarchy prior was not provided");
     }
@@ -123,16 +123,16 @@ class BaseHierarchy : public AbstractHierarchy {
 
  protected:
   //! Re-initializes the prior of the hierarchy to a newly created object
-  void create_empty_prior() { prior.reset(new Prior); }
+  void create_empty_prior() override { prior.reset(new Prior); }
 
   //! Sets the cluster's cardinality
-  void set_card(const int card_) {
+  void set_card(const int card_) override {
     card = card_;
     log_card = std::log(card_);
   }
 
   //! Removes all indicators of data points belonging to this cluster
-  void clear_data() {
+  void clear_data() override {
     card = 0;
     // TODO log_card?
     cluster_data_idx = std::set<int>();
@@ -140,14 +140,14 @@ class BaseHierarchy : public AbstractHierarchy {
 
   //! Down-casts the given generic proto message to a ClusterState proto
   bayesmix::AlgorithmState::ClusterState *downcast_state(
-      google::protobuf::Message *state_) const {
+      google::protobuf::Message *state_) const override {
     return google::protobuf::internal::down_cast<
         bayesmix::AlgorithmState::ClusterState *>(state_);
   }
 
   //! Down-casts the given generic proto message to a ClusterState proto
   const bayesmix::AlgorithmState::ClusterState &downcast_state(
-      const google::protobuf::Message &state_) const {
+      const google::protobuf::Message &state_) const override {
     return google::protobuf::internal::down_cast<
         const bayesmix::AlgorithmState::ClusterState &>(state_);
   }

--- a/src/hierarchies/conjugate_hierarchy.h
+++ b/src/hierarchies/conjugate_hierarchy.h
@@ -89,7 +89,7 @@ class ConjugateHierarchy
     } else {
       Hyperparams params =
           update_params
-              ? static_cast<Derived *>(this)->get_posterior_parameters()
+              ? static_cast<Derived *>(this)->compute_posterior_hypers()
               : posterior_hypers;
       state = static_cast<Derived *>(this)->draw(params);
     }
@@ -98,7 +98,7 @@ class ConjugateHierarchy
   //! Saves posterior hyperparameters to the corresponding class member
   void save_posterior_hypers() {
     posterior_hypers =
-        static_cast<Derived *>(this)->get_posterior_parameters();
+        static_cast<Derived *>(this)->compute_posterior_hypers();
   }
 
   //! Returns whether the hierarchy represents a conjugate model or not

--- a/src/hierarchies/lin_reg_uni_hierarchy.cc
+++ b/src/hierarchies/lin_reg_uni_hierarchy.cc
@@ -101,7 +101,7 @@ void LinRegUniHierarchy::clear_summary_statistics() {
   covar_sum_squares = Eigen::MatrixXd::Zero(dim, dim);
 }
 
-LinRegUni::Hyperparams LinRegUniHierarchy::get_posterior_parameters() {
+LinRegUni::Hyperparams LinRegUniHierarchy::get_posterior_parameters() const {
   if (card == 0) {  // no update possible
     return *hypers;
   }

--- a/src/hierarchies/lin_reg_uni_hierarchy.cc
+++ b/src/hierarchies/lin_reg_uni_hierarchy.cc
@@ -101,7 +101,7 @@ void LinRegUniHierarchy::clear_summary_statistics() {
   covar_sum_squares = Eigen::MatrixXd::Zero(dim, dim);
 }
 
-LinRegUni::Hyperparams LinRegUniHierarchy::get_posterior_parameters() const {
+LinRegUni::Hyperparams LinRegUniHierarchy::compute_posterior_hypers() const {
   if (card == 0) {  // no update possible
     return *hypers;
   }

--- a/src/hierarchies/lin_reg_uni_hierarchy.h
+++ b/src/hierarchies/lin_reg_uni_hierarchy.h
@@ -66,7 +66,7 @@ class LinRegUniHierarchy
                                  bool add) override;
 
   //! Resets summary statistics for this cluster
-  void clear_summary_statistics();
+  void clear_summary_statistics() override;
 
   //! Returns the Protobuf ID associated to this class
   bayesmix::HierarchyId get_id() const override {
@@ -91,12 +91,6 @@ class LinRegUniHierarchy
   //! Computes and return posterior hypers given data currently in this cluster
   LinRegUni::Hyperparams compute_posterior_hypers() const;
 
-  //! Initializes state parameters to appropriate values
-  void initialize_state();
-
-  //! Initializes hierarchy hyperparameters to appropriate values
-  void initialize_hypers();
-
   //! Returns whether the hierarchy models multivariate data or not
   bool is_multivariate() const override { return false; }
 
@@ -119,6 +113,12 @@ class LinRegUniHierarchy
   double marg_lpdf(const LinRegUni::Hyperparams &params,
                    const Eigen::RowVectorXd &datum,
                    const Eigen::RowVectorXd &covariate) const override;
+
+  //! Initializes state parameters to appropriate values
+  void initialize_state() override;
+
+  //! Initializes hierarchy hyperparameters to appropriate values
+  void initialize_hypers() override;
 
   //! Dimension of the coefficients vector
   unsigned int dim;

--- a/src/hierarchies/lin_reg_uni_hierarchy.h
+++ b/src/hierarchies/lin_reg_uni_hierarchy.h
@@ -50,12 +50,6 @@ class LinRegUniHierarchy
   LinRegUniHierarchy() = default;
   ~LinRegUniHierarchy() = default;
 
-  //! Initializes state parameters to appropriate values
-  void initialize_state() override;
-
-  //! Initializes hierarchy hyperparameters to appropriate values
-  void initialize_hypers() override;
-
   //! Updates hyperparameter values given a vector of cluster states
   void update_hypers(const std::vector<bayesmix::AlgorithmState::ClusterState>
                          &states) override;
@@ -71,20 +65,13 @@ class LinRegUniHierarchy
                                  const Eigen::RowVectorXd &covariate,
                                  bool add) override;
 
-  //! Removes every data point from this cluster
-  void clear_summary_statistics();
+  //! Resets summary statistics for this cluster
+  void clear_summary_statistics() override;
 
-  //! Returns the dimension of the coefficients vector
-  unsigned int get_dim() const { return dim; }
-
-  //! Returns whether the hierarchy models multivariate data or not
-  bool is_multivariate() const override { return false; }
-
-  //! Returns whether the hierarchy depends on covariate values or not
-  bool is_dependent() const override { return true; }
-
-  //! Computes and return posterior hypers given data currently in this cluster
-  LinRegUni::Hyperparams get_posterior_parameters() const;
+  //! Returns the Protobuf ID associated to this class
+  bayesmix::HierarchyId get_id() const override {
+    return bayesmix::HierarchyId::LinRegUni;
+  }
 
   //! Read and set state values from a given Protobuf message
   void set_state_from_proto(const google::protobuf::Message &state_) override;
@@ -98,10 +85,17 @@ class LinRegUniHierarchy
   //! Writes current state to a Protobuf message by pointer
   void write_hypers_to_proto(google::protobuf::Message *out) const override;
 
-  //! Returns the Protobuf ID associated to this class
-  bayesmix::HierarchyId get_id() const override {
-    return bayesmix::HierarchyId::LinRegUni;
-  }
+  //! Returns the dimension of the coefficients vector
+  unsigned int get_dim() const { return dim; }
+
+  //! Computes and return posterior hypers given data currently in this cluster
+  LinRegUni::Hyperparams get_posterior_parameters() const;
+
+  //! Returns whether the hierarchy models multivariate data or not
+  bool is_multivariate() const override { return false; }
+
+  //! Returns whether the hierarchy depends on covariate values or not
+  bool is_dependent() const override { return true; }
 
  protected:
   //! Evaluates the log-likelihood of data in a single point
@@ -119,6 +113,12 @@ class LinRegUniHierarchy
   double marg_lpdf(const LinRegUni::Hyperparams &params,
                    const Eigen::RowVectorXd &datum,
                    const Eigen::RowVectorXd &covariate) const override;
+
+  //! Initializes state parameters to appropriate values
+  void initialize_state() override;
+
+  //! Initializes hierarchy hyperparameters to appropriate values
+  void initialize_hypers() override;
 
   //! Dimension of the coefficients vector
   unsigned int dim;

--- a/src/hierarchies/lin_reg_uni_hierarchy.h
+++ b/src/hierarchies/lin_reg_uni_hierarchy.h
@@ -84,7 +84,7 @@ class LinRegUniHierarchy
   bool is_dependent() const override { return true; }
 
   //! Computes and return posterior hypers given data currently in this cluster
-  LinRegUni::Hyperparams get_posterior_parameters();
+  LinRegUni::Hyperparams get_posterior_parameters() const;
 
   //! Read and set state values from a given Protobuf message
   void set_state_from_proto(const google::protobuf::Message &state_) override;

--- a/src/hierarchies/lin_reg_uni_hierarchy.h
+++ b/src/hierarchies/lin_reg_uni_hierarchy.h
@@ -89,7 +89,7 @@ class LinRegUniHierarchy
   unsigned int get_dim() const { return dim; }
 
   //! Computes and return posterior hypers given data currently in this cluster
-  LinRegUni::Hyperparams get_posterior_parameters() const;
+  LinRegUni::Hyperparams compute_posterior_hypers() const;
 
   //! Initializes state parameters to appropriate values
   void initialize_state();

--- a/src/hierarchies/lin_reg_uni_hierarchy.h
+++ b/src/hierarchies/lin_reg_uni_hierarchy.h
@@ -66,7 +66,7 @@ class LinRegUniHierarchy
                                  bool add) override;
 
   //! Resets summary statistics for this cluster
-  void clear_summary_statistics() override;
+  void clear_summary_statistics();
 
   //! Returns the Protobuf ID associated to this class
   bayesmix::HierarchyId get_id() const override {
@@ -91,6 +91,12 @@ class LinRegUniHierarchy
   //! Computes and return posterior hypers given data currently in this cluster
   LinRegUni::Hyperparams get_posterior_parameters() const;
 
+  //! Initializes state parameters to appropriate values
+  void initialize_state();
+
+  //! Initializes hierarchy hyperparameters to appropriate values
+  void initialize_hypers();
+
   //! Returns whether the hierarchy models multivariate data or not
   bool is_multivariate() const override { return false; }
 
@@ -113,12 +119,6 @@ class LinRegUniHierarchy
   double marg_lpdf(const LinRegUni::Hyperparams &params,
                    const Eigen::RowVectorXd &datum,
                    const Eigen::RowVectorXd &covariate) const override;
-
-  //! Initializes state parameters to appropriate values
-  void initialize_state() override;
-
-  //! Initializes hierarchy hyperparameters to appropriate values
-  void initialize_hypers() override;
 
   //! Dimension of the coefficients vector
   unsigned int dim;

--- a/src/hierarchies/nnig_hierarchy.cc
+++ b/src/hierarchies/nnig_hierarchy.cc
@@ -205,7 +205,7 @@ void NNIGHierarchy::clear_summary_statistics() {
   data_sum_squares = 0;
 }
 
-NNIG::Hyperparams NNIGHierarchy::get_posterior_parameters() const {
+NNIG::Hyperparams NNIGHierarchy::compute_posterior_hypers() const {
   // Initialize relevant variables
   if (card == 0) {  // no update possible
     return *hypers;

--- a/src/hierarchies/nnig_hierarchy.cc
+++ b/src/hierarchies/nnig_hierarchy.cc
@@ -205,7 +205,7 @@ void NNIGHierarchy::clear_summary_statistics() {
   data_sum_squares = 0;
 }
 
-NNIG::Hyperparams NNIGHierarchy::get_posterior_parameters() {
+NNIG::Hyperparams NNIGHierarchy::get_posterior_parameters() const {
   // Initialize relevant variables
   if (card == 0) {  // no update possible
     return *hypers;

--- a/src/hierarchies/nnig_hierarchy.h
+++ b/src/hierarchies/nnig_hierarchy.h
@@ -54,7 +54,7 @@ class NNIGHierarchy
   NNIG::State draw(const NNIG::Hyperparams &params);
 
   //! Resets summary statistics for this cluster
-  void clear_summary_statistics() override;
+  void clear_summary_statistics();
 
   //! Returns the Protobuf ID associated to this class
   bayesmix::HierarchyId get_id() const override {
@@ -75,6 +75,12 @@ class NNIGHierarchy
 
   //! Computes and return posterior hypers given data currently in this cluster
   NNIG::Hyperparams get_posterior_parameters() const;
+
+  //! Initializes state parameters to appropriate values
+  void initialize_state();
+
+  //! Initializes hierarchy hyperparameters to appropriate values
+  void initialize_hypers();
 
   //! Returns whether the hierarchy models multivariate data or not
   bool is_multivariate() const override { return false; }
@@ -97,12 +103,6 @@ class NNIGHierarchy
   //! @param add        Whether the datum is being added or removed
   void update_summary_statistics(const Eigen::RowVectorXd &datum,
                                  bool add) override;
-
-  //! Initializes state parameters to appropriate values
-  void initialize_state() override;
-
-  //! Initializes hierarchy hyperparameters to appropriate values
-  void initialize_hypers() override;
 
   //! Sum of data points currently belonging to the cluster
   double data_sum = 0;

--- a/src/hierarchies/nnig_hierarchy.h
+++ b/src/hierarchies/nnig_hierarchy.h
@@ -54,7 +54,7 @@ class NNIGHierarchy
   NNIG::State draw(const NNIG::Hyperparams &params);
 
   //! Resets summary statistics for this cluster
-  void clear_summary_statistics();
+  void clear_summary_statistics() override;
 
   //! Returns the Protobuf ID associated to this class
   bayesmix::HierarchyId get_id() const override {
@@ -75,12 +75,6 @@ class NNIGHierarchy
 
   //! Computes and return posterior hypers given data currently in this cluster
   NNIG::Hyperparams compute_posterior_hypers() const;
-
-  //! Initializes state parameters to appropriate values
-  void initialize_state();
-
-  //! Initializes hierarchy hyperparameters to appropriate values
-  void initialize_hypers();
 
   //! Returns whether the hierarchy models multivariate data or not
   bool is_multivariate() const override { return false; }
@@ -103,6 +97,12 @@ class NNIGHierarchy
   //! @param add        Whether the datum is being added or removed
   void update_summary_statistics(const Eigen::RowVectorXd &datum,
                                  bool add) override;
+
+  //! Initializes state parameters to appropriate values
+  void initialize_state() override;
+
+  //! Initializes hierarchy hyperparameters to appropriate values
+  void initialize_hypers() override;
 
   //! Sum of data points currently belonging to the cluster
   double data_sum = 0;

--- a/src/hierarchies/nnig_hierarchy.h
+++ b/src/hierarchies/nnig_hierarchy.h
@@ -74,7 +74,7 @@ class NNIGHierarchy
   void write_hypers_to_proto(google::protobuf::Message *out) const override;
 
   //! Computes and return posterior hypers given data currently in this cluster
-  NNIG::Hyperparams get_posterior_parameters() const;
+  NNIG::Hyperparams compute_posterior_hypers() const;
 
   //! Initializes state parameters to appropriate values
   void initialize_state();

--- a/src/hierarchies/nnig_hierarchy.h
+++ b/src/hierarchies/nnig_hierarchy.h
@@ -66,7 +66,7 @@ class NNIGHierarchy
   bool is_multivariate() const override { return false; }
 
   //! Computes and return posterior hypers given data currently in this cluster
-  NNIG::Hyperparams get_posterior_parameters();
+  NNIG::Hyperparams get_posterior_parameters() const;
 
   //! Read and set state values from a given Protobuf message
   void set_state_from_proto(const google::protobuf::Message &state_) override;

--- a/src/hierarchies/nnig_hierarchy.h
+++ b/src/hierarchies/nnig_hierarchy.h
@@ -46,12 +46,6 @@ class NNIGHierarchy
   NNIGHierarchy() = default;
   ~NNIGHierarchy() = default;
 
-  //! Initializes state parameters to appropriate values
-  void initialize_state() override;
-
-  //! Initializes hierarchy hyperparameters to appropriate values
-  void initialize_hypers() override;
-
   //! Updates hyperparameter values given a vector of cluster states
   void update_hypers(const std::vector<bayesmix::AlgorithmState::ClusterState>
                          &states) override;
@@ -59,14 +53,13 @@ class NNIGHierarchy
   //! Updates state values using the given (prior or posterior) hyperparameters
   NNIG::State draw(const NNIG::Hyperparams &params);
 
-  //! Removes every data point from this cluster
-  void clear_summary_statistics();
+  //! Resets summary statistics for this cluster
+  void clear_summary_statistics() override;
 
-  //! Returns whether the hierarchy models multivariate data or not
-  bool is_multivariate() const override { return false; }
-
-  //! Computes and return posterior hypers given data currently in this cluster
-  NNIG::Hyperparams get_posterior_parameters() const;
+  //! Returns the Protobuf ID associated to this class
+  bayesmix::HierarchyId get_id() const override {
+    return bayesmix::HierarchyId::NNIG;
+  }
 
   //! Read and set state values from a given Protobuf message
   void set_state_from_proto(const google::protobuf::Message &state_) override;
@@ -80,10 +73,11 @@ class NNIGHierarchy
   //! Writes current state to a Protobuf message by pointer
   void write_hypers_to_proto(google::protobuf::Message *out) const override;
 
-  //! Returns the Protobuf ID associated to this class
-  bayesmix::HierarchyId get_id() const override {
-    return bayesmix::HierarchyId::NNIG;
-  }
+  //! Computes and return posterior hypers given data currently in this cluster
+  NNIG::Hyperparams get_posterior_parameters() const;
+
+  //! Returns whether the hierarchy models multivariate data or not
+  bool is_multivariate() const override { return false; }
 
  protected:
   //! Evaluates the log-likelihood of data in a single point
@@ -103,6 +97,12 @@ class NNIGHierarchy
   //! @param add        Whether the datum is being added or removed
   void update_summary_statistics(const Eigen::RowVectorXd &datum,
                                  bool add) override;
+
+  //! Initializes state parameters to appropriate values
+  void initialize_state() override;
+
+  //! Initializes hierarchy hyperparameters to appropriate values
+  void initialize_hypers() override;
 
   //! Sum of data points currently belonging to the cluster
   double data_sum = 0;

--- a/src/hierarchies/nnw_hierarchy.cc
+++ b/src/hierarchies/nnw_hierarchy.cc
@@ -54,7 +54,7 @@ Eigen::VectorXd NNWHierarchy::conditional_pred_lpdf_grid(
     const Eigen::MatrixXd &data, const Eigen::MatrixXd &covariates) const {
   // Custom, optimized grid method
   NNW::Hyperparams pred_params =
-      get_predictive_t_parameters(get_posterior_parameters());
+      get_predictive_t_parameters(compute_posterior_hypers());
   Eigen::VectorXd diag = pred_params.scale_chol.diagonal();
   double logdet = 2 * log(diag.array()).sum();
 
@@ -281,7 +281,7 @@ void NNWHierarchy::clear_summary_statistics() {
   data_sum_squares = Eigen::MatrixXd::Zero(dim, dim);
 }
 
-NNW::Hyperparams NNWHierarchy::get_posterior_parameters() const {
+NNW::Hyperparams NNWHierarchy::compute_posterior_hypers() const {
   if (card == 0) {  // no update possible
     return *hypers;
   }

--- a/src/hierarchies/nnw_hierarchy.h
+++ b/src/hierarchies/nnw_hierarchy.h
@@ -82,12 +82,6 @@ class NNWHierarchy
       const Eigen::MatrixXd &covariates = Eigen::MatrixXd(0,
                                                           0)) const override;
 
-  //! Initializes state parameters to appropriate values
-  void initialize_state() override;
-
-  //! Initializes hierarchy hyperparameters to appropriate values
-  void initialize_hypers() override;
-
   //! Updates hyperparameter values given a vector of cluster states
   void update_hypers(const std::vector<bayesmix::AlgorithmState::ClusterState>
                          &states) override;
@@ -95,11 +89,13 @@ class NNWHierarchy
   //! Updates state values using the given (prior or posterior) hyperparameters
   NNW::State draw(const NNW::Hyperparams &params);
 
-  //! Removes every data point from this cluster
-  void clear_summary_statistics();
+  //! Resets summary statistics for this cluster
+  void clear_summary_statistics() override;
 
-  //! Returns whether the hierarchy models multivariate data or not
-  bool is_multivariate() const override { return true; }
+  //! Returns the Protobuf ID associated to this class
+  bayesmix::HierarchyId get_id() const override {
+    return bayesmix::HierarchyId::NNW;
+  }
 
   //! Computes and return posterior hypers given data currently in this cluster
   NNW::Hyperparams get_posterior_parameters() const;
@@ -116,10 +112,8 @@ class NNWHierarchy
   //! Writes current state to a Protobuf message by pointer
   void write_hypers_to_proto(google::protobuf::Message *out) const override;
 
-  //! Returns the Protobuf ID associated to this class
-  bayesmix::HierarchyId get_id() const override {
-    return bayesmix::HierarchyId::NNW;
-  }
+  //! Returns whether the hierarchy models multivariate data or not
+  bool is_multivariate() const override { return true; }
 
  protected:
   //! Evaluates the log-likelihood of data in a single point
@@ -146,6 +140,12 @@ class NNWHierarchy
   //! Returns parameters for the predictive Student's t distribution
   NNW::Hyperparams get_predictive_t_parameters(
       const NNW::Hyperparams &params) const;
+
+  //! Initializes state parameters to appropriate values
+  void initialize_state() override;
+
+  //! Initializes hierarchy hyperparameters to appropriate values
+  void initialize_hypers() override;
 
   //! Dimension of data space
   unsigned int dim;

--- a/src/hierarchies/nnw_hierarchy.h
+++ b/src/hierarchies/nnw_hierarchy.h
@@ -98,7 +98,7 @@ class NNWHierarchy
   }
 
   //! Computes and return posterior hypers given data currently in this cluster
-  NNW::Hyperparams get_posterior_parameters() const;
+  NNW::Hyperparams compute_posterior_hypers() const;
 
   //! Read and set state values from a given Protobuf message
   void set_state_from_proto(const google::protobuf::Message &state_) override;

--- a/src/hierarchies/nnw_hierarchy.h
+++ b/src/hierarchies/nnw_hierarchy.h
@@ -90,7 +90,7 @@ class NNWHierarchy
   NNW::State draw(const NNW::Hyperparams &params);
 
   //! Resets summary statistics for this cluster
-  void clear_summary_statistics() override;
+  void clear_summary_statistics();
 
   //! Returns the Protobuf ID associated to this class
   bayesmix::HierarchyId get_id() const override {
@@ -111,6 +111,12 @@ class NNWHierarchy
 
   //! Writes current state to a Protobuf message by pointer
   void write_hypers_to_proto(google::protobuf::Message *out) const override;
+
+  //! Initializes state parameters to appropriate values
+  void initialize_state();
+
+  //! Initializes hierarchy hyperparameters to appropriate values
+  void initialize_hypers();
 
   //! Returns whether the hierarchy models multivariate data or not
   bool is_multivariate() const override { return true; }
@@ -140,12 +146,6 @@ class NNWHierarchy
   //! Returns parameters for the predictive Student's t distribution
   NNW::Hyperparams get_predictive_t_parameters(
       const NNW::Hyperparams &params) const;
-
-  //! Initializes state parameters to appropriate values
-  void initialize_state() override;
-
-  //! Initializes hierarchy hyperparameters to appropriate values
-  void initialize_hypers() override;
 
   //! Dimension of data space
   unsigned int dim;

--- a/src/hierarchies/nnw_hierarchy.h
+++ b/src/hierarchies/nnw_hierarchy.h
@@ -90,7 +90,7 @@ class NNWHierarchy
   NNW::State draw(const NNW::Hyperparams &params);
 
   //! Resets summary statistics for this cluster
-  void clear_summary_statistics();
+  void clear_summary_statistics() override;
 
   //! Returns the Protobuf ID associated to this class
   bayesmix::HierarchyId get_id() const override {
@@ -111,12 +111,6 @@ class NNWHierarchy
 
   //! Writes current state to a Protobuf message by pointer
   void write_hypers_to_proto(google::protobuf::Message *out) const override;
-
-  //! Initializes state parameters to appropriate values
-  void initialize_state();
-
-  //! Initializes hierarchy hyperparameters to appropriate values
-  void initialize_hypers();
 
   //! Returns whether the hierarchy models multivariate data or not
   bool is_multivariate() const override { return true; }
@@ -146,6 +140,12 @@ class NNWHierarchy
   //! Returns parameters for the predictive Student's t distribution
   NNW::Hyperparams get_predictive_t_parameters(
       const NNW::Hyperparams &params) const;
+
+  //! Initializes state parameters to appropriate values
+  void initialize_state() override;
+
+  //! Initializes hierarchy hyperparameters to appropriate values
+  void initialize_hypers() override;
 
   //! Dimension of data space
   unsigned int dim;

--- a/src/mixings/abstract_mixing.h
+++ b/src/mixings/abstract_mixing.h
@@ -45,8 +45,11 @@ class AbstractMixing {
   AbstractMixing() = default;
   virtual ~AbstractMixing() = default;
 
-  //! Initializes class members to appropriate values
+  //! Main function that initializes members to appropriate values
   virtual void initialize() = 0;
+
+  //! Initializes the mixing state to appropriate values
+  virtual void initialize_state() = 0;
 
   //! Performs conditional update of state, given allocations and unique values
   //! @param unique_values  A vector of (pointers to) Hierarchy objects
@@ -69,7 +72,7 @@ class AbstractMixing {
         return mixing_weights(log, propto);
       }
     }
-  };
+  }
 
   //! Public wrapper for `mass_existing_cluster()` methods
   double get_mass_existing_cluster(
@@ -142,7 +145,7 @@ class AbstractMixing {
     } else {
       throw std::runtime_error("Not implemented");
     }
-  };
+  }
 
   //! Returns mixing weights (for conditional mixings only)
   //! @param log        Whether to return logarithm-scale values or not
@@ -156,7 +159,7 @@ class AbstractMixing {
     } else {
       throw std::runtime_error("Not implemented");
     }
-  };
+  }
 
   //! Returns probability mass for an old cluster (for marginal mixings only)
   //! @param n          Total dataset size
@@ -175,7 +178,7 @@ class AbstractMixing {
     } else {
       throw std::runtime_error("Not implemented");
     }
-  };
+  }
 
   //! Returns probability mass for an old cluster (for marginal mixings only)
   //! @param n          Total dataset size
@@ -192,7 +195,7 @@ class AbstractMixing {
     } else {
       throw std::runtime_error("Not implemented");
     }
-  };
+  }
 
   //! Returns probability mass for a new cluster (for marginal mixings only)
   //! @param n          Total dataset size
@@ -211,7 +214,7 @@ class AbstractMixing {
     } else {
       throw std::runtime_error("Not implemented");
     }
-  };
+  }
 
   //! Returns probability mass for a new cluster (for marginal mixings only)
   //! @param n          Total dataset size
@@ -228,7 +231,18 @@ class AbstractMixing {
     } else {
       throw std::runtime_error("Not implemented");
     }
-  };
+  }
+
+  //! Re-initializes the prior of the mixing to a newly created object
+  virtual void create_empty_prior() = 0;
+
+  //! Down-casts the given generic proto message to a MixingState proto
+  virtual bayesmix::MixingState *downcast_state(
+      google::protobuf::Message *out) const = 0;
+
+  //! Down-casts the given generic proto message to a MixingState proto
+  virtual const bayesmix::MixingState &downcast_state(
+      const google::protobuf::Message &state_) const = 0;
 };
 
 #endif  // BAYESMIX_MIXINGS_ABSTRACT_MIXING_H_

--- a/src/mixings/abstract_mixing.h
+++ b/src/mixings/abstract_mixing.h
@@ -108,6 +108,7 @@ class AbstractMixing {
   virtual void set_state_from_proto(
       const google::protobuf::Message &state_) = 0;
 
+  //! Writes current state to a Protobuf message by pointer
   virtual void write_state_to_proto(google::protobuf::Message *out) const = 0;
 
   //! Writes current state to a Protobuf message and return a shared_ptr

--- a/src/mixings/abstract_mixing.h
+++ b/src/mixings/abstract_mixing.h
@@ -111,11 +111,6 @@ class AbstractMixing {
   //! Writes current state to a Protobuf message by pointer
   virtual void write_state_to_proto(google::protobuf::Message *out) const = 0;
 
-  //! Writes current state to a Protobuf message and return a shared_ptr
-  //! New hierarchies have to first modify the field 'oneof val' in the
-  //! MixingState message by adding the appropriate type
-  virtual std::shared_ptr<bayesmix::MixingState> get_state_proto() const = 0;
-
   //! Returns the Protobuf ID associated to this class
   virtual bayesmix::MixingId get_id() const = 0;
 

--- a/src/mixings/abstract_mixing.h
+++ b/src/mixings/abstract_mixing.h
@@ -233,17 +233,6 @@ class AbstractMixing {
 
   //! Initializes the mixing state to appropriate values
   virtual void initialize_state() = 0;
-
-  //! Re-initializes the prior of the mixing to a newly created object
-  virtual void create_empty_prior() = 0;
-
-  //! Down-casts the given generic proto message to a MixingState proto
-  virtual bayesmix::MixingState *downcast_state(
-      google::protobuf::Message *out) const = 0;
-
-  //! Down-casts the given generic proto message to a MixingState proto
-  virtual const bayesmix::MixingState &downcast_state(
-      const google::protobuf::Message &state_) const = 0;
 };
 
 #endif  // BAYESMIX_MIXINGS_ABSTRACT_MIXING_H_

--- a/src/mixings/abstract_mixing.h
+++ b/src/mixings/abstract_mixing.h
@@ -230,9 +230,6 @@ class AbstractMixing {
       throw std::runtime_error("Not implemented");
     }
   }
-
-  //! Initializes the mixing state to appropriate values
-  virtual void initialize_state() = 0;
 };
 
 #endif  // BAYESMIX_MIXINGS_ABSTRACT_MIXING_H_

--- a/src/mixings/abstract_mixing.h
+++ b/src/mixings/abstract_mixing.h
@@ -45,12 +45,6 @@ class AbstractMixing {
   AbstractMixing() = default;
   virtual ~AbstractMixing() = default;
 
-  //! Main function that initializes members to appropriate values
-  virtual void initialize() = 0;
-
-  //! Initializes the mixing state to appropriate values
-  virtual void initialize_state() = 0;
-
   //! Performs conditional update of state, given allocations and unique values
   //! @param unique_values  A vector of (pointers to) Hierarchy objects
   //! @param allocations    A vector of allocations label
@@ -123,6 +117,9 @@ class AbstractMixing {
 
   //! Returns the Protobuf ID associated to this class
   virtual bayesmix::MixingId get_id() const = 0;
+
+  //! Main function that initializes members to appropriate values
+  virtual void initialize() = 0;
 
   //! Returns whether the mixing is conditional or marginal
   virtual bool is_conditional() const = 0;
@@ -232,6 +229,9 @@ class AbstractMixing {
       throw std::runtime_error("Not implemented");
     }
   }
+
+  //! Initializes the mixing state to appropriate values
+  virtual void initialize_state() = 0;
 
   //! Re-initializes the prior of the mixing to a newly created object
   virtual void create_empty_prior() = 0;

--- a/src/mixings/base_mixing.h
+++ b/src/mixings/base_mixing.h
@@ -54,6 +54,9 @@ class BaseMixing : public AbstractMixing {
   //! Main function that initializes members to appropriate values
   void initialize() override;
 
+  //! Initializes state parameters to appropriate values
+  virtual void initialize_state() = 0;
+
  protected:
   //! Re-initializes the prior of the mixing to a newly created object
   void create_empty_prior() { prior.reset(new Prior); }
@@ -109,7 +112,7 @@ void BaseMixing<Derived, State, Prior>::initialize() {
   if (prior == nullptr) {
     throw std::invalid_argument("Mixing prior was not provided");
   }
-  static_cast<Derived *>(this)->initialize_state();
+  initialize_state();
 }
 
 #endif  // BAYESMIX_MIXINGS_BASE_MIXING_H_

--- a/src/mixings/base_mixing.h
+++ b/src/mixings/base_mixing.h
@@ -54,12 +54,12 @@ class BaseMixing : public AbstractMixing {
   //! Main function that initializes members to appropriate values
   void initialize() override;
 
-  //! Initializes state parameters to appropriate values
-  virtual void initialize_state() = 0;
-
  protected:
   //! Re-initializes the prior of the mixing to a newly created object
   void create_empty_prior() { prior.reset(new Prior); }
+
+  //! Initializes state parameters to appropriate values
+  virtual void initialize_state() = 0;
 
   //! Down-casts the given generic proto message to a MixingState proto
   bayesmix::MixingState *downcast_state(google::protobuf::Message *out) const {

--- a/src/mixings/base_mixing.h
+++ b/src/mixings/base_mixing.h
@@ -56,17 +56,16 @@ class BaseMixing : public AbstractMixing {
 
  protected:
   //! Re-initializes the prior of the mixing to a newly created object
-  void create_empty_prior() override { prior.reset(new Prior); }
+  void create_empty_prior() { prior.reset(new Prior); }
 
   //! Down-casts the given generic proto message to a MixingState proto
-  bayesmix::MixingState *downcast_state(
-      google::protobuf::Message *out) const override {
+  bayesmix::MixingState *downcast_state(google::protobuf::Message *out) const {
     return google::protobuf::internal::down_cast<bayesmix::MixingState *>(out);
   }
 
   //! Down-casts the given generic proto message to a MixingState proto
   const bayesmix::MixingState &downcast_state(
-      const google::protobuf::Message &state_) const override {
+      const google::protobuf::Message &state_) const {
     return google::protobuf::internal::down_cast<
         const bayesmix::MixingState &>(state_);
   }

--- a/src/mixings/base_mixing.h
+++ b/src/mixings/base_mixing.h
@@ -109,7 +109,7 @@ void BaseMixing<Derived, State, Prior>::initialize() {
   if (prior == nullptr) {
     throw std::invalid_argument("Mixing prior was not provided");
   }
-  initialize_state();
+  static_cast<Derived *>(this)->initialize_state();
 }
 
 #endif  // BAYESMIX_MIXINGS_BASE_MIXING_H_

--- a/src/mixings/base_mixing.h
+++ b/src/mixings/base_mixing.h
@@ -56,19 +56,17 @@ class BaseMixing : public AbstractMixing {
 
  protected:
   //! Re-initializes the prior of the mixing to a newly created object
-  void create_empty_prior() { prior.reset(new Prior); }
-
-  //! Initializes the mixing state to appropriate values
-  virtual void initialize_state() = 0;
+  void create_empty_prior() override { prior.reset(new Prior); }
 
   //! Down-casts the given generic proto message to a MixingState proto
-  bayesmix::MixingState *downcast_state(google::protobuf::Message *out) const {
+  bayesmix::MixingState *downcast_state(
+      google::protobuf::Message *out) const override {
     return google::protobuf::internal::down_cast<bayesmix::MixingState *>(out);
   }
 
   //! Down-casts the given generic proto message to a MixingState proto
   const bayesmix::MixingState &downcast_state(
-      const google::protobuf::Message &state_) const {
+      const google::protobuf::Message &state_) const override {
     return google::protobuf::internal::down_cast<
         const bayesmix::MixingState &>(state_);
   }

--- a/src/mixings/base_mixing.h
+++ b/src/mixings/base_mixing.h
@@ -51,6 +51,11 @@ class BaseMixing : public AbstractMixing {
   //! Writes current state to a Protobuf message by pointer
   void write_state_to_proto(google::protobuf::Message *out) const override;
 
+  //! Writes current state to a Protobuf message and return a shared_ptr
+  //! New hierarchies have to first modify the field 'oneof val' in the
+  //! MixingState message by adding the appropriate type
+  virtual std::shared_ptr<bayesmix::MixingState> get_state_proto() const = 0;
+
   //! Main function that initializes members to appropriate values
   void initialize() override;
 

--- a/src/mixings/dirichlet_mixing.h
+++ b/src/mixings/dirichlet_mixing.h
@@ -54,9 +54,6 @@ class DirichletMixing
   //! Returns the Protobuf ID associated to this class
   bayesmix::MixingId get_id() const override { return bayesmix::MixingId::DP; }
 
-  //! Initializes state parameters to appropriate values
-  void initialize_state();
-
   //! Returns whether the mixing is conditional or marginal
   bool is_conditional() const override { return false; }
 
@@ -80,6 +77,9 @@ class DirichletMixing
   double mass_new_cluster(const unsigned int n, const bool log,
                           const bool propto,
                           const unsigned int n_clust) const override;
+
+  //! Initializes state parameters to appropriate values
+  void initialize_state() override;
 };
 
 #endif  // BAYESMIX_MIXINGS_DIRICHLET_MIXING_H_

--- a/src/mixings/dirichlet_mixing.h
+++ b/src/mixings/dirichlet_mixing.h
@@ -43,6 +43,21 @@ class DirichletMixing
       const std::vector<std::shared_ptr<AbstractHierarchy>> &unique_values,
       const std::vector<unsigned int> &allocations) override;
 
+  //! Read and set state values from a given Protobuf message
+  void set_state_from_proto(const google::protobuf::Message &state_) override;
+
+  //! Writes current state to a Protobuf message and return a shared_ptr
+  //! New hierarchies have to first modify the field 'oneof val' in the
+  //! MixingState message by adding the appropriate type
+  std::shared_ptr<bayesmix::MixingState> get_state_proto() const override;
+
+  //! Returns the Protobuf ID associated to this class
+  bayesmix::MixingId get_id() const override { return bayesmix::MixingId::DP; }
+
+  //! Returns whether the mixing is conditional or marginal
+  bool is_conditional() const override { return false; }
+
+ protected:
   //! Returns probability mass for an old cluster (for marginal mixings only)
   //! @param n          Total dataset size
   //! @param log        Whether to return logarithm-scale values or not
@@ -63,21 +78,6 @@ class DirichletMixing
                           const bool propto,
                           const unsigned int n_clust) const override;
 
-  //! Read and set state values from a given Protobuf message
-  void set_state_from_proto(const google::protobuf::Message &state_) override;
-
-  //! Writes current state to a Protobuf message and return a shared_ptr
-  //! New hierarchies have to first modify the field 'oneof val' in the
-  //! MixingState message by adding the appropriate type
-  std::shared_ptr<bayesmix::MixingState> get_state_proto() const override;
-
-  //! Returns the Protobuf ID associated to this class
-  bayesmix::MixingId get_id() const override { return bayesmix::MixingId::DP; }
-
-  //! Returns whether the mixing is conditional or marginal
-  bool is_conditional() const override { return false; }
-
- protected:
   void initialize_state() override;
 };
 

--- a/src/mixings/dirichlet_mixing.h
+++ b/src/mixings/dirichlet_mixing.h
@@ -54,6 +54,9 @@ class DirichletMixing
   //! Returns the Protobuf ID associated to this class
   bayesmix::MixingId get_id() const override { return bayesmix::MixingId::DP; }
 
+  //! Initializes state parameters to appropriate values
+  void initialize_state();
+
   //! Returns whether the mixing is conditional or marginal
   bool is_conditional() const override { return false; }
 
@@ -77,8 +80,6 @@ class DirichletMixing
   double mass_new_cluster(const unsigned int n, const bool log,
                           const bool propto,
                           const unsigned int n_clust) const override;
-
-  void initialize_state() override;
 };
 
 #endif  // BAYESMIX_MIXINGS_DIRICHLET_MIXING_H_

--- a/src/mixings/logit_sb_mixing.h
+++ b/src/mixings/logit_sb_mixing.h
@@ -67,9 +67,6 @@ class LogitSBMixing
     return acceptance_rates / n_iter;
   }
 
-  //! Initializes state parameters to appropriate values
-  void initialize_state();
-
   //! Returns whether the mixing is conditional or marginal
   bool is_conditional() const override { return true; }
 
@@ -85,6 +82,9 @@ class LogitSBMixing
   Eigen::VectorXd mixing_weights(
       const bool log, const bool propto,
       const Eigen::RowVectorXd &covariate) const override;
+
+  //! Initializes state parameters to appropriate values
+  void initialize_state() override;
 
   //! Sigmoid function
   double sigmoid(const double x) const { return 1.0 / (1.0 + std::exp(-x)); }

--- a/src/mixings/logit_sb_mixing.h
+++ b/src/mixings/logit_sb_mixing.h
@@ -67,6 +67,9 @@ class LogitSBMixing
     return acceptance_rates / n_iter;
   }
 
+  //! Initializes state parameters to appropriate values
+  void initialize_state();
+
   //! Returns whether the mixing is conditional or marginal
   bool is_conditional() const override { return true; }
 
@@ -82,9 +85,6 @@ class LogitSBMixing
   Eigen::VectorXd mixing_weights(
       const bool log, const bool propto,
       const Eigen::RowVectorXd &covariate) const override;
-
-  //! Initializes state parameters to appropriate values
-  void initialize_state() override;
 
   //! Sigmoid function
   double sigmoid(const double x) const { return 1.0 / (1.0 + std::exp(-x)); }

--- a/src/mixings/logit_sb_mixing.h
+++ b/src/mixings/logit_sb_mixing.h
@@ -49,15 +49,6 @@ class LogitSBMixing
       const std::vector<std::shared_ptr<AbstractHierarchy>> &unique_values,
       const std::vector<unsigned int> &allocations) override;
 
-  //! Returns mixing weights (for conditional mixings only)
-  //! @param log        Whether to return logarithm-scale values or not
-  //! @param propto     Whether to include normalizing constants or not
-  //! @param covariate  Covariate vector
-  //! @return           The vector of mixing weights
-  Eigen::VectorXd mixing_weights(
-      const bool log, const bool propto,
-      const Eigen::RowVectorXd &covariate) const override;
-
   //! Read and set state values from a given Protobuf message
   void set_state_from_proto(const google::protobuf::Message &state_) override;
 
@@ -83,6 +74,15 @@ class LogitSBMixing
   bool is_dependent() const override { return true; }
 
  protected:
+  //! Returns mixing weights (for conditional mixings only)
+  //! @param log        Whether to return logarithm-scale values or not
+  //! @param propto     Whether to include normalizing constants or not
+  //! @param covariate  Covariate vector
+  //! @return           The vector of mixing weights
+  Eigen::VectorXd mixing_weights(
+      const bool log, const bool propto,
+      const Eigen::RowVectorXd &covariate) const override;
+
   //! Initializes state parameters to appropriate values
   void initialize_state() override;
 

--- a/src/mixings/pityor_mixing.h
+++ b/src/mixings/pityor_mixing.h
@@ -56,9 +56,6 @@ class PitYorMixing
   //! Returns the Protobuf ID associated to this class
   bayesmix::MixingId get_id() const override { return bayesmix::MixingId::PY; }
 
-  //! Initializes state parameters to appropriate values
-  void initialize_state();
-
   //! Returns whether the mixing is conditional or marginal
   bool is_conditional() const override { return false; }
 
@@ -82,6 +79,9 @@ class PitYorMixing
   double mass_new_cluster(const unsigned int n, const bool log,
                           const bool propto,
                           const unsigned int n_clust) const override;
+
+  //! Initializes state parameters to appropriate values
+  void initialize_state() override;
 };
 
 #endif  // BAYESMIX_MIXINGS_PITYOR_MIXING_H_

--- a/src/mixings/pityor_mixing.h
+++ b/src/mixings/pityor_mixing.h
@@ -45,6 +45,23 @@ class PitYorMixing
       const std::vector<std::shared_ptr<AbstractHierarchy>> &unique_values,
       const std::vector<unsigned int> &allocations) override;
 
+  //! Read and set state values from a given Protobuf message
+  void set_state_from_proto(const google::protobuf::Message &state_) override;
+
+  //! Writes current state to a Protobuf message and return a shared_ptr
+  //! New hierarchies have to first modify the field 'oneof val' in the
+  //! MixingState message by adding the appropriate type
+  std::shared_ptr<bayesmix::MixingState> get_state_proto() const override;
+
+  //! Returns the Protobuf ID associated to this class
+  bayesmix::MixingId get_id() const override { return bayesmix::MixingId::PY; }
+
+  //! Returns whether the mixing is conditional or marginal
+  bool is_conditional() const override { return false; }
+
+ protected:
+  void initialize_state() override;
+
   //! Returns probability mass for an old cluster (for marginal mixings only)
   //! @param n          Total dataset size
   //! @param log        Whether to return logarithm-scale values or not
@@ -64,23 +81,6 @@ class PitYorMixing
   double mass_new_cluster(const unsigned int n, const bool log,
                           const bool propto,
                           const unsigned int n_clust) const override;
-
-  //! Read and set state values from a given Protobuf message
-  void set_state_from_proto(const google::protobuf::Message &state_) override;
-
-  //! Writes current state to a Protobuf message and return a shared_ptr
-  //! New hierarchies have to first modify the field 'oneof val' in the
-  //! MixingState message by adding the appropriate type
-  std::shared_ptr<bayesmix::MixingState> get_state_proto() const override;
-
-  //! Returns the Protobuf ID associated to this class
-  bayesmix::MixingId get_id() const override { return bayesmix::MixingId::PY; }
-
-  //! Returns whether the mixing is conditional or marginal
-  bool is_conditional() const override { return false; }
-
- protected:
-  void initialize_state() override;
 };
 
 #endif  // BAYESMIX_MIXINGS_PITYOR_MIXING_H_

--- a/src/mixings/pityor_mixing.h
+++ b/src/mixings/pityor_mixing.h
@@ -56,12 +56,13 @@ class PitYorMixing
   //! Returns the Protobuf ID associated to this class
   bayesmix::MixingId get_id() const override { return bayesmix::MixingId::PY; }
 
+  //! Initializes state parameters to appropriate values
+  void initialize_state();
+
   //! Returns whether the mixing is conditional or marginal
   bool is_conditional() const override { return false; }
 
  protected:
-  void initialize_state() override;
-
   //! Returns probability mass for an old cluster (for marginal mixings only)
   //! @param n          Total dataset size
   //! @param log        Whether to return logarithm-scale values or not

--- a/src/mixings/truncated_sb_mixing.h
+++ b/src/mixings/truncated_sb_mixing.h
@@ -62,13 +62,13 @@ class TruncatedSBMixing : public BaseMixing<TruncatedSBMixing, TruncSB::State,
     return bayesmix::MixingId::TruncSB;
   }
 
+  //! Initializes state parameters to appropriate values
+  void initialize_state();
+
   //! Returns whether the mixing is conditional or marginal
   bool is_conditional() const override { return true; }
 
  protected:
-  //! Initializes state parameters to appropriate values
-  void initialize_state() override;
-
   //! Returns mixing weights (for conditional mixings only)
   //! @param log        Whether to return logarithm-scale values or not
   //! @param propto     Whether to include normalizing constants or not

--- a/src/mixings/truncated_sb_mixing.h
+++ b/src/mixings/truncated_sb_mixing.h
@@ -62,9 +62,6 @@ class TruncatedSBMixing : public BaseMixing<TruncatedSBMixing, TruncSB::State,
     return bayesmix::MixingId::TruncSB;
   }
 
-  //! Initializes state parameters to appropriate values
-  void initialize_state();
-
   //! Returns whether the mixing is conditional or marginal
   bool is_conditional() const override { return true; }
 
@@ -75,6 +72,9 @@ class TruncatedSBMixing : public BaseMixing<TruncatedSBMixing, TruncSB::State,
   //! @return           The vector of mixing weights
   Eigen::VectorXd mixing_weights(const bool log,
                                  const bool propto) const override;
+
+  //! Initializes state parameters to appropriate values
+  void initialize_state() override;
 
   //! Returns weights in log-scale computing them from sticks
   Eigen::VectorXd logweights_from_sticks() const;

--- a/src/mixings/truncated_sb_mixing.h
+++ b/src/mixings/truncated_sb_mixing.h
@@ -49,13 +49,6 @@ class TruncatedSBMixing : public BaseMixing<TruncatedSBMixing, TruncSB::State,
       const std::vector<std::shared_ptr<AbstractHierarchy>> &unique_values,
       const std::vector<unsigned int> &allocations) override;
 
-  //! Returns mixing weights (for conditional mixings only)
-  //! @param log        Whether to return logarithm-scale values or not
-  //! @param propto     Whether to include normalizing constants or not
-  //! @return           The vector of mixing weights
-  Eigen::VectorXd mixing_weights(const bool log,
-                                 const bool propto) const override;
-
   //! Read and set state values from a given Protobuf message
   void set_state_from_proto(const google::protobuf::Message &state_) override;
 
@@ -75,6 +68,13 @@ class TruncatedSBMixing : public BaseMixing<TruncatedSBMixing, TruncSB::State,
  protected:
   //! Initializes state parameters to appropriate values
   void initialize_state() override;
+
+  //! Returns mixing weights (for conditional mixings only)
+  //! @param log        Whether to return logarithm-scale values or not
+  //! @param propto     Whether to include normalizing constants or not
+  //! @return           The vector of mixing weights
+  Eigen::VectorXd mixing_weights(const bool log,
+                                 const bool propto) const override;
 
   //! Returns weights in log-scale computing them from sticks
   Eigen::VectorXd logweights_from_sticks() const;


### PR DESCRIPTION
I feel that code-changing cleanup, which is not merely adding docstrings and switching functions around, however small, deservs its own pull request. Besides updated docstrings, formatting, and function order, changes fall in one of the following categories, mainly affecting hierarchies:
* moved or added functions to abstract classes, deleting static casts if no longer necessary
* changed functions from public to protected
* fixed small details related to cluster cardinality
* added `const`s and `override`s and whatnot.

Moreover, there's one more thing to discuss. In `BaseHierarchy` we have `get_posterior_hypers()` which is a simple getter, while in individual derived hierarchies we have `get_posterior_parameters()`, which also returns posterior hypers but after computing them in a posterior update. Should we rename `get_posterior_parameters()`? Maybe to `compute_posterior_hypers()`?

EDIT: Whoops, I just read your hierarchy README. There was a reason for some methods not to be virtual after all. I'll revert back some changes.