### PR TITLE
async reading from file collector

### DIFF
--- a/examples/tutorial/run.sh
+++ b/examples/tutorial/run.sh
@@ -19,9 +19,9 @@ build/run \
   resources/tutorial/algo.asciipb \
   NNIG resources/tutorial/nnig_ngg.asciipb \
   DP   resources/tutorial/dp_gamma.asciipb \
-  "" \
+  resources/tutorial/out/chains.recordio \
   resources/tutorial/data.csv \
   resources/tutorial/grid.csv \
-  resources/tutorial/out/density.csv \
+  resources/tutorial/out/density_file.csv \
   resources/tutorial/out/numclust.csv \
   resources/tutorial/out/clustering.csv

--- a/src/collectors/file_collector.h
+++ b/src/collectors/file_collector.h
@@ -8,17 +8,14 @@
 
 #include "base_collector.h"
 
-//! Class for a collector that writes its content to a file.
+//! Class for a collector that writes (and reads) its content to a file.
 
-//! This is a type of collector that writes each state passed to it to a binary
-//! file. Unlike the memory collector, the contents of this collector are
-//! permanent, because every state collected by it remains ever after the
-//! termination of the main that created it, in Protobuf form, in the
-//! corresponding file. This approach is mandatory, for instance, if different
-//! main programs are used both to run the algorithm and the estimates.
-//! Therefore, a file collector has both a reading and a writing mode.
-//! For more information about collectors, please refer to the `BaseCollector`
-//! base class.
+//! An instance of FileCollector saves a sequence of Protobuf objects to a file
+//! and is able to read them back, returning them one by one. When writing to
+//! the file, the objects are simply serialized into bytes. When reading, for
+//! efficiency's sake, we instead read a chunk of 'chunk_size' objects and
+//! deserialized them into a buffer, asynchronously. When the buffer has been
+//! read, we erase it and fill it again with the next chunk of objects.
 
 class FileCollector : public BaseCollector {
  public:
@@ -53,6 +50,7 @@ class FileCollector : public BaseCollector {
 
   bool next_state(google::protobuf::Message *out) override;
 
+  //! Populates the buffer with the next chunk of objects.
   void populate_buffer(google::protobuf::Message *base_msg);
 
   //! Unix file descriptor for reading mode
@@ -65,10 +63,15 @@ class FileCollector : public BaseCollector {
 
   int curr_buffer_pos;
 
+  //! Buffer of std::future objects, one per message. std::future is needed
+  //! to perform the reading asynchronously.
   std::vector<std::future<
       std::tuple<std::shared_ptr<google::protobuf::Message>, bool>>>
       msg_buffer;
 
+  //! Reads one message from the file and returns a tuple containing (a shared
+  //! ptr to) the message and a bool indicating whether the message was
+  //! successfully read.
   std::tuple<std::shared_ptr<google::protobuf::Message>, bool> read_one(
       google::protobuf::Message *base_msg);
 

--- a/src/collectors/memory_collector.h
+++ b/src/collectors/memory_collector.h
@@ -6,18 +6,11 @@
 
 #include "base_collector.h"
 
-//! Class for a "virtual" collector which contains all objects of the chain
+//! Class for a collector that writes its content into memory.
 
-//! This is a type of collector which includes a deque containing all states of
-//! the chain. Unlike the file collector, this is a purely "virtual" collector,
-//! in the sense that it does not write chain states anywhere and all
-//! information contained in it is destroyed when the main that created it is
-//! terminated. It is therefore useful in situation in which writing to a file
-//! is not needed, for instance in a main program that both runes and algorithm
-//! and computes the estimates. In this cases, this collector is more efficient
-//! than its file-writing counterpart.
-//! For more information about collectors, please refer to the `BaseCollector`
-//! base class.
+//! An instance of MemoryCollector saves a sequence of Protobuf objects
+//! by storing byte-serialized objects into a deque of strings.
+//! When reading, the objects are simply deserialized from the deque.
 
 class MemoryCollector : public BaseCollector {
  public:


### PR DESCRIPTION
This is a small PR with a huge impact on performance.

When using the FileCollector in the "examples/tutorial/run.sh" we go from almost two minutes to evaluate the log_density to 0.58s (for comparison, MemoryCollector takes 0.571s)

This is based on asynchronously reading a chunk of messages into a buffer, instead of reading the file one message every time.