### PR TITLE
Improved CSV reading function

### DIFF
--- a/run_mcmc.cc
+++ b/run_mcmc.cc
@@ -6,33 +6,22 @@
 #include "lib/argparse/argparse.h"
 #include "src/includes.h"
 
-bool check_file_is_writeable(std::string filename) {
-  std::ofstream ofstr;
-  ofstr.open(filename);
-  if (ofstr.fail()) {
-    std::cerr << "Error: cannot write to " << filename << std::endl;
-    ofstr.close();
-    return false;
-  }
-  ofstr.close();
-  return true;
-}
-
 bool check_args(argparse::ArgumentParser args) {
   if (args["--coll-name"] != std::string("memory")) {
-    check_file_is_writeable(args.get<std::string>("--coll-name"));
+    bayesmix::check_file_is_writeable(args.get<std::string>("--coll-name"));
   }
   if (args["--dens-file"] != std::string("\"\"")) {
-    check_file_is_writeable(args.get<std::string>("--dens-file"));
+    bayesmix::check_file_is_writeable(args.get<std::string>("--dens-file"));
   }
   if (args["--n-cl-file"] != std::string("\"\"")) {
-    check_file_is_writeable(args.get<std::string>("--n-cl-file"));
+    bayesmix::check_file_is_writeable(args.get<std::string>("--n-cl-file"));
   }
   if (args["--clus-file"] != std::string("\"\"")) {
-    check_file_is_writeable(args.get<std::string>("--clus-file"));
+    bayesmix::check_file_is_writeable(args.get<std::string>("--clus-file"));
   }
   if (args["--best-clus-file"] != std::string("\"\"")) {
-    check_file_is_writeable(args.get<std::string>("--best-clus-file"));
+    bayesmix::check_file_is_writeable(
+        args.get<std::string>("--best-clus-file"));
   }
 
   return true;

--- a/src/utils/io_utils.cc
+++ b/src/utils/io_utils.cc
@@ -2,46 +2,63 @@
 
 #include <Eigen/Dense>
 #include <fstream>
+#include <iostream>
+
+bool bayesmix::check_file_is_writeable(const std::string &filename) {
+  std::ofstream ofstr;
+  ofstr.open(filename);
+  if (ofstr.fail()) {
+    ofstr.close();
+    throw std::invalid_argument("Cannot write to " + filename);
+  }
+  ofstr.close();
+  return true;
+}
 
 Eigen::MatrixXd bayesmix::read_eigen_matrix(const std::string &filename,
                                             const char delim /* = ','*/) {
   // Initialize objects
-  unsigned int cols = 0, rows = 0;
-  double buffer[MAXBUFSIZE];
+  unsigned int rows = 0, cols = 0;
   std::ifstream filestream(filename);
   if (!filestream.is_open()) {
     std::string err = "File " + filename + " does not exist";
     throw std::invalid_argument(err);
   }
 
-  // Loop over file lines
+  // Get number of rows and columns
   std::string line, entry;
   while (getline(filestream, line, '\n')) {
-    unsigned int temp = 0;
+    rows++;
+    if (rows == 1) {
+      std::stringstream linestream(line);
+      while (getline(linestream, entry, delim)) {
+        cols++;
+      }
+    }
+  }
+  filestream.seekg(0);
+
+  // Fill an Eigen Matrix with values from the matrix
+  Eigen::MatrixXd mat(rows, cols);
+  unsigned int i = 0, j = 0;
+  while (getline(filestream, line, '\n')) {
     std::stringstream linestream(line);
     while (getline(linestream, entry, delim)) {
-      // Place read values into the buffer array
       std::stringstream entrystream(entry);
-      entrystream >> buffer[cols * rows + temp++];
+      entrystream >> mat(i, j);
+      j++;
     }
-    if (temp == 0) {
-      continue;
-    }
-    if (cols == 0) {
-      cols = temp;
-    }
-    rows++;
+    i++;
+  }
+
+  for (int x = 0; i < mat.rows(); i++) {
+    for (int y = 0; i < mat.cols(); i++) std::cout << mat(x, y) << " ";
+    std::cout << std::endl;
   }
 
   filestream.close();
+  std::cout << rows << " " << cols << std::endl;
 
-  // Fill an Eigen Matrix with values from the buffer array
-  Eigen::MatrixXd mat(rows, cols);
-  for (size_t i = 0; i < rows; i++) {
-    for (size_t j = 0; j < cols; j++) {
-      mat(i, j) = buffer[cols * i + j];
-    }
-  }
   return mat;
 };
 

--- a/src/utils/io_utils.cc
+++ b/src/utils/io_utils.cc
@@ -18,7 +18,7 @@ bool bayesmix::check_file_is_writeable(const std::string &filename) {
 Eigen::MatrixXd bayesmix::read_eigen_matrix(const std::string &filename,
                                             const char delim /* = ','*/) {
   // Initialize objects
-  unsigned int rows = 0, cols = 0;
+  int rows = 0, cols = 0;
   std::ifstream filestream(filename);
   if (!filestream.is_open()) {
     std::string err = "File " + filename + " does not exist";
@@ -36,29 +36,25 @@ Eigen::MatrixXd bayesmix::read_eigen_matrix(const std::string &filename,
       }
     }
   }
-  filestream.seekg(0);
+  // Reset file stream to the beginning of the file
+  filestream.clear();
+  filestream.seekg(0, std::ios::beg);
 
   // Fill an Eigen Matrix with values from the matrix
   Eigen::MatrixXd mat(rows, cols);
-  unsigned int i = 0, j = 0;
+  int i = 0;
   while (getline(filestream, line, '\n')) {
+    int j = 0;
     std::stringstream linestream(line);
     while (getline(linestream, entry, delim)) {
       std::stringstream entrystream(entry);
-      entrystream >> mat(i, j);
+      mat(i, j) = std::stof(entry);
       j++;
     }
     i++;
   }
 
-  for (int x = 0; i < mat.rows(); i++) {
-    for (int y = 0; i < mat.cols(); i++) std::cout << mat(x, y) << " ";
-    std::cout << std::endl;
-  }
-
   filestream.close();
-  std::cout << rows << " " << cols << std::endl;
-
   return mat;
 };
 

--- a/src/utils/io_utils.h
+++ b/src/utils/io_utils.h
@@ -6,9 +6,10 @@
 //! This file implements basic input-output utilities for Eigen matrices from
 //! and to text files.
 
-#define MAXBUFSIZE ((int)1e6)
-
 namespace bayesmix {
+//! Checks whether the given file is available for writing
+bool check_file_is_writeable(const std::string &filename);
+
 //! Returns an Eigen matrix after reading it from a file
 Eigen::MatrixXd read_eigen_matrix(const std::string &filename,
                                   const char delim = ',');


### PR DESCRIPTION
The new `read_eigen_matrix()` removes the often-limiting maximum buffer size to read from a matrix. It first scans the given CSV to infer the correct number of rows and columns, then allocates the matrix of the exact dimensions needed, and finally fills it entry-by-entry. (While I was at it, I also moved `check_file_is_writeable()` to the utils file.)

@giacomodecarlo, as soon as this is merged into master, you can merge the master into your own branch to use this function :)