### PR TITLE
Segfault correction in Split&Merge algorithm

### DIFF
--- a/src/algorithms/split_and_merge_algorithm.cc
+++ b/src/algorithms/split_and_merge_algorithm.cc
@@ -269,13 +269,10 @@ void SplitAndMergeAlgorithm::proposal_update_allocations(
     data_to_move_idx = unique_values[label_old_cluster]->get_data_idx();
   }
 
-  auto curr_it = data_to_move_idx.cbegin();
-  auto next_it = curr_it;
-  next_it++;
-  auto end_it = data_to_move_idx.cend();
-  for (; curr_it != end_it; next_it++, curr_it++) {
-    const unsigned int curr_idx = *curr_it;
-    if (next_it == end_it) {
+  for (auto it = data_to_move_idx.cbegin(); it != data_to_move_idx.cend();
+       it++) {
+    const unsigned int curr_idx = *it;
+    if (it == (--data_to_move_idx.cend())) {
       if (split) {
         unique_values[label_old_cluster]->remove_datum(
             curr_idx, data.row(curr_idx), update_hierarchy_params());


### PR DESCRIPTION
I corrected the function proposal_update_allocations() in the implementation of the Split&Merge algorithm: in the last iteration of the for loop the iterator `next_it` was pointing to the element after the `end_it`, causing, in some cases, a segmentation fault. Following the suggestion of @mberaha, I removed `next_it` and modified the if clause where it was used. 