### PR TITLE
State template

### DIFF
--- a/src/hierarchies/base_hierarchy.h
+++ b/src/hierarchies/base_hierarchy.h
@@ -211,7 +211,7 @@ class BaseHierarchy : public AbstractHierarchy {
 
   //! Generates new state values from the centering prior distribution
   void sample_prior() override {
-    like->set_state_from_proto(*prior->sample(), false);
+    like->set_state(prior->sample(), false);
   };
 
   //! Generates new state values from the centering posterior distribution

--- a/src/hierarchies/base_hierarchy.h
+++ b/src/hierarchies/base_hierarchy.h
@@ -210,9 +210,7 @@ class BaseHierarchy : public AbstractHierarchy {
   }
 
   //! Generates new state values from the centering prior distribution
-  void sample_prior() override {
-    like->set_state(prior->sample(), false);
-  };
+  void sample_prior() override { like->set_state(prior->sample(), false); };
 
   //! Generates new state values from the centering posterior distribution
   //! @param update_params  Save posterior hypers after the computation?
@@ -260,7 +258,8 @@ class BaseHierarchy : public AbstractHierarchy {
   //! AlgoritmState::ClusterState message by adding the appropriate type
   std::shared_ptr<bayesmix::AlgorithmState::ClusterState> get_state_proto()
       const override {
-    return like->get_state_proto();
+    return std::make_shared<bayesmix::AlgorithmState::ClusterState>(
+        like->get_state().get_as_proto());
   }
 
   //! Returns a pointer to the Protobuf message of the prior of this cluster

--- a/src/hierarchies/fa_hierarchy.h
+++ b/src/hierarchies/fa_hierarchy.h
@@ -32,9 +32,8 @@ class FAHierarchy
     state.psi = hypers.beta / (hypers.alpha0 + 1.);
     state.lambda = Eigen::MatrixXd::Zero(dim, hypers.q);
     state.psi_inverse = state.psi.cwiseInverse().asDiagonal();
+    state.compute_wood_factors();
     like->set_state(state);
-    like->compute_wood_factors(state.cov_wood, state.cov_logdet, state.lambda,
-                               state.psi_inverse);
   }
 };
 

--- a/src/hierarchies/likelihoods/CMakeLists.txt
+++ b/src/hierarchies/likelihoods/CMakeLists.txt
@@ -6,12 +6,12 @@ target_sources(bayesmix PUBLIC
     uni_norm_likelihood.cc
     multi_norm_likelihood.h
     multi_norm_likelihood.cc
-    uni_lin_reg_likelihood.h
-    uni_lin_reg_likelihood.cc
-    laplace_likelihood.h
-    laplace_likelihood.cc
-    fa_likelihood.h
-    fa_likelihood.cc
+    # uni_lin_reg_likelihood.h
+    # uni_lin_reg_likelihood.cc
+    # laplace_likelihood.h
+    # laplace_likelihood.cc
+    # fa_likelihood.h
+    # fa_likelihood.cc
 )
 
 add_subdirectory(states)

--- a/src/hierarchies/likelihoods/CMakeLists.txt
+++ b/src/hierarchies/likelihoods/CMakeLists.txt
@@ -6,12 +6,12 @@ target_sources(bayesmix PUBLIC
     uni_norm_likelihood.cc
     multi_norm_likelihood.h
     multi_norm_likelihood.cc
-    # uni_lin_reg_likelihood.h
-    # uni_lin_reg_likelihood.cc
-    # laplace_likelihood.h
-    # laplace_likelihood.cc
-    # fa_likelihood.h
-    # fa_likelihood.cc
+    uni_lin_reg_likelihood.h
+    uni_lin_reg_likelihood.cc
+    laplace_likelihood.h
+    laplace_likelihood.cc
+    fa_likelihood.h
+    fa_likelihood.cc
 )
 
 add_subdirectory(states)

--- a/src/hierarchies/likelihoods/abstract_likelihood.h
+++ b/src/hierarchies/likelihoods/abstract_likelihood.h
@@ -117,12 +117,6 @@ class AbstractLikelihood {
   virtual Eigen::VectorXd get_unconstrained_state() = 0;
 
  protected:
-  //! Writes current state to a Protobuf message and return a shared_ptr
-  //! New hierarchies have to first modify the field 'oneof val' in the
-  //! AlgoritmState::ClusterState message by adding the appropriate type
-  virtual std::shared_ptr<bayesmix::AlgorithmState::ClusterState>
-  get_state_proto() const = 0;
-
   //! Evaluates the log-likelihood of data in a single point
   //! @param datum      Point which is to be evaluated
   //! @return           The evaluation of the lpdf

--- a/src/hierarchies/likelihoods/base_likelihood.h
+++ b/src/hierarchies/likelihoods/base_likelihood.h
@@ -84,7 +84,7 @@ class BaseLikelihood : public AbstractLikelihood {
   //! Returns the class of the current state for the likelihood
   State get_state() const { return state; }
 
-  State* mutable_state() { return &state; }
+  State *mutable_state() { return &state; }
 
   //! Returns a vector storing the state in its unconstrained form
   Eigen::VectorXd get_unconstrained_state() override {
@@ -92,7 +92,19 @@ class BaseLikelihood : public AbstractLikelihood {
   }
 
   //! Updates the state of the likelihood with the object given as input
-  void set_state(const State &_state) { state = _state; };
+  void set_state(const State & state_, bool update_card = true) {
+    state = state_;
+    if (update_card) {
+      set_card(state.card);
+    }
+  };
+
+  void set_state_from_proto(const google::protobuf::Message &state_,
+                                    bool update_card = true) override {
+      State new_state;
+      new_state.set_from_proto(downcast_state(state_), update_card);
+      set_state(new_state, update_card);
+  }
 
   //! Updates the state of the likelihood starting from its unconstrained form
   void set_state_from_unconstrained(

--- a/src/hierarchies/likelihoods/base_likelihood.h
+++ b/src/hierarchies/likelihoods/base_likelihood.h
@@ -92,7 +92,7 @@ class BaseLikelihood : public AbstractLikelihood {
   }
 
   //! Updates the state of the likelihood with the object given as input
-  void set_state(const State & state_, bool update_card = true) {
+  void set_state(const State &state_, bool update_card = true) {
     state = state_;
     if (update_card) {
       set_card(state.card);
@@ -100,10 +100,10 @@ class BaseLikelihood : public AbstractLikelihood {
   };
 
   void set_state_from_proto(const google::protobuf::Message &state_,
-                                    bool update_card = true) override {
-      State new_state;
-      new_state.set_from_proto(downcast_state(state_), update_card);
-      set_state(new_state, update_card);
+                            bool update_card = true) override {
+    State new_state;
+    new_state.set_from_proto(downcast_state(state_), update_card);
+    set_state(new_state, update_card);
   }
 
   //! Updates the state of the likelihood starting from its unconstrained form
@@ -199,10 +199,8 @@ void BaseLikelihood<Derived, State>::remove_datum(
 template <class Derived, typename State>
 void BaseLikelihood<Derived, State>::write_state_to_proto(
     google::protobuf::Message *out) const {
-  std::shared_ptr<bayesmix::AlgorithmState::ClusterState> state_ =
-      get_state_proto();
   auto *out_cast = downcast_state(out);
-  out_cast->CopyFrom(*state_.get());
+  out_cast->CopyFrom(state.get_as_proto());
   out_cast->set_cardinality(card);
 }
 

--- a/src/hierarchies/likelihoods/base_likelihood.h
+++ b/src/hierarchies/likelihoods/base_likelihood.h
@@ -84,6 +84,8 @@ class BaseLikelihood : public AbstractLikelihood {
   //! Returns the class of the current state for the likelihood
   State get_state() const { return state; }
 
+  State* mutable_state() { return &state; }
+
   //! Returns a vector storing the state in its unconstrained form
   Eigen::VectorXd get_unconstrained_state() override {
     return internal::get_unconstrained_state(state, 0);

--- a/src/hierarchies/likelihoods/fa_likelihood.cc
+++ b/src/hierarchies/likelihoods/fa_likelihood.cc
@@ -2,34 +2,8 @@
 
 #include "src/utils/distributions.h"
 
-void FALikelihood::set_state_from_proto(
-    const google::protobuf::Message& state_, bool update_card) {
-  auto& statecast = downcast_state(state_);
-  state.mu = bayesmix::to_eigen(statecast.fa_state().mu());
-  state.psi = bayesmix::to_eigen(statecast.fa_state().psi());
-  state.eta = bayesmix::to_eigen(statecast.fa_state().eta());
-  state.lambda = bayesmix::to_eigen(statecast.fa_state().lambda());
-  state.psi_inverse = state.psi.cwiseInverse().asDiagonal();
-  compute_wood_factors(state.cov_wood, state.cov_logdet, state.lambda,
-                       state.psi_inverse);
-  if (update_card) set_card(statecast.cardinality());
-}
-
 void FALikelihood::clear_summary_statistics() {
   data_sum = Eigen::VectorXd::Zero(dim);
-}
-
-std::shared_ptr<bayesmix::AlgorithmState::ClusterState>
-FALikelihood::get_state_proto() const {
-  bayesmix::FAState state_;
-  bayesmix::to_proto(state.mu, state_.mutable_mu());
-  bayesmix::to_proto(state.psi, state_.mutable_psi());
-  bayesmix::to_proto(state.eta, state_.mutable_eta());
-  bayesmix::to_proto(state.lambda, state_.mutable_lambda());
-
-  auto out = std::make_shared<bayesmix::AlgorithmState::ClusterState>();
-  out->mutable_fa_state()->CopyFrom(state_);
-  return out;
 }
 
 double FALikelihood::compute_lpdf(const Eigen::RowVectorXd& datum) const {
@@ -44,14 +18,4 @@ void FALikelihood::update_sum_stats(const Eigen::RowVectorXd& datum,
   } else {
     data_sum -= datum;
   }
-}
-
-void FALikelihood::compute_wood_factors(
-    Eigen::MatrixXd& cov_wood, double& cov_logdet,
-    const Eigen::MatrixXd& lambda,
-    const Eigen::DiagonalMatrix<double, Eigen::Dynamic>& psi_inverse) {
-  auto [cov_wood_, cov_logdet_] =
-      bayesmix::compute_wood_chol_and_logdet(psi_inverse, lambda);
-  cov_logdet = cov_logdet_;
-  cov_wood = cov_wood_;
 }

--- a/src/hierarchies/likelihoods/fa_likelihood.h
+++ b/src/hierarchies/likelihoods/fa_likelihood.h
@@ -18,8 +18,6 @@ class FALikelihood : public BaseLikelihood<FALikelihood, State::FA> {
   ~FALikelihood() = default;
   bool is_multivariate() const override { return true; };
   bool is_dependent() const override { return false; };
-  void set_state_from_proto(const google::protobuf::Message& state_,
-                            bool update_card = true) override;
   void clear_summary_statistics() override;
   void set_dim(unsigned int dim_) {
     dim = dim_;
@@ -27,14 +25,6 @@ class FALikelihood : public BaseLikelihood<FALikelihood, State::FA> {
   };
   unsigned int get_dim() const { return dim; };
   Eigen::VectorXd get_data_sum() const { return data_sum; };
-
-  std::shared_ptr<bayesmix::AlgorithmState::ClusterState> get_state_proto()
-      const override;
-
-  void compute_wood_factors(
-      Eigen::MatrixXd& cov_wood, double& cov_logdet,
-      const Eigen::MatrixXd& lambda,
-      const Eigen::DiagonalMatrix<double, Eigen::Dynamic>& psi_inverse);
 
  protected:
   double compute_lpdf(const Eigen::RowVectorXd& datum) const override;

--- a/src/hierarchies/likelihoods/laplace_likelihood.cc
+++ b/src/hierarchies/likelihoods/laplace_likelihood.cc
@@ -4,19 +4,3 @@ double LaplaceLikelihood::compute_lpdf(const Eigen::RowVectorXd &datum) const {
   return stan::math::double_exponential_lpdf(
       datum(0), state.mean, stan::math::sqrt(state.var / 2.0));
 }
-
-void LaplaceLikelihood::set_state_from_proto(
-    const google::protobuf::Message &state_, bool update_card) {
-  auto &statecast = downcast_state(state_);
-  state.mean = statecast.uni_ls_state().mean();
-  state.var = statecast.uni_ls_state().var();
-  if (update_card) set_card(statecast.cardinality());
-}
-
-std::shared_ptr<bayesmix::AlgorithmState::ClusterState>
-LaplaceLikelihood::get_state_proto() const {
-  auto out = std::make_shared<bayesmix::AlgorithmState::ClusterState>();
-  out->mutable_uni_ls_state()->set_mean(state.mean);
-  out->mutable_uni_ls_state()->set_var(state.var);
-  return out;
-}

--- a/src/hierarchies/likelihoods/laplace_likelihood.h
+++ b/src/hierarchies/likelihoods/laplace_likelihood.h
@@ -18,8 +18,6 @@ class LaplaceLikelihood
   ~LaplaceLikelihood() = default;
   bool is_multivariate() const override { return false; };
   bool is_dependent() const override { return false; };
-  void set_state_from_proto(const google::protobuf::Message &state_,
-                            bool update_card = true) override;
   void clear_summary_statistics() override { return; };
 
   template <typename T>
@@ -38,9 +36,6 @@ class LaplaceLikelihood
     }
     return out;
   }
-
-  std::shared_ptr<bayesmix::AlgorithmState::ClusterState> get_state_proto()
-      const override;
 
  protected:
   double compute_lpdf(const Eigen::RowVectorXd &datum) const override;

--- a/src/hierarchies/likelihoods/multi_norm_likelihood.cc
+++ b/src/hierarchies/likelihoods/multi_norm_likelihood.cc
@@ -25,28 +25,6 @@ void MultiNormLikelihood::update_sum_stats(const Eigen::RowVectorXd &datum,
   }
 }
 
-void MultiNormLikelihood::set_state_from_proto(
-    const google::protobuf::Message &state_, bool update_card) {
-  auto &statecast = downcast_state(state_);
-  state.mean = to_eigen(statecast.multi_ls_state().mean());
-  state.prec = to_eigen(statecast.multi_ls_state().prec());
-  state.prec_chol = to_eigen(statecast.multi_ls_state().prec_chol());
-  Eigen::VectorXd diag = state.prec_chol.diagonal();
-  state.prec_logdet = 2 * log(diag.array()).sum();
-  if (update_card) set_card(statecast.cardinality());
-}
-
-std::shared_ptr<bayesmix::AlgorithmState::ClusterState>
-MultiNormLikelihood::get_state_proto() const {
-  bayesmix::MultiLSState state_;
-  bayesmix::to_proto(state.mean, state_.mutable_mean());
-  bayesmix::to_proto(state.prec, state_.mutable_prec());
-  bayesmix::to_proto(state.prec_chol, state_.mutable_prec_chol());
-  auto out = std::make_shared<bayesmix::AlgorithmState::ClusterState>();
-  out->mutable_multi_ls_state()->CopyFrom(state_);
-  return out;
-}
-
 void MultiNormLikelihood::clear_summary_statistics() {
   data_sum = Eigen::VectorXd::Zero(dim);
   data_sum_squares = Eigen::MatrixXd::Zero(dim, dim);

--- a/src/hierarchies/likelihoods/multi_norm_likelihood.h
+++ b/src/hierarchies/likelihoods/multi_norm_likelihood.h
@@ -19,8 +19,6 @@ class MultiNormLikelihood
   ~MultiNormLikelihood() = default;
   bool is_multivariate() const override { return true; };
   bool is_dependent() const override { return false; };
-  void set_state_from_proto(const google::protobuf::Message &state_,
-                            bool update_card = true) override;
   void clear_summary_statistics() override;
 
   void set_dim(unsigned int dim_) {
@@ -30,9 +28,6 @@ class MultiNormLikelihood
   unsigned int get_dim() const { return dim; };
   Eigen::VectorXd get_data_sum() const { return data_sum; };
   Eigen::MatrixXd get_data_sum_squares() const { return data_sum_squares; };
-
-  std::shared_ptr<bayesmix::AlgorithmState::ClusterState> get_state_proto()
-      const override;
 
  protected:
   double compute_lpdf(const Eigen::RowVectorXd &datum) const override;

--- a/src/hierarchies/likelihoods/states/CMakeLists.txt
+++ b/src/hierarchies/likelihoods/states/CMakeLists.txt
@@ -3,6 +3,6 @@ target_sources(bayesmix PUBLIC
     base_state.h
     uni_ls_state.h
     multi_ls_state.h
-    # uni_lin_reg_ls_state.h
+    uni_lin_reg_ls_state.h
     # fa_state.h
 )

--- a/src/hierarchies/likelihoods/states/CMakeLists.txt
+++ b/src/hierarchies/likelihoods/states/CMakeLists.txt
@@ -2,7 +2,7 @@ target_sources(bayesmix PUBLIC
     includes.h
     base_state.h
     uni_ls_state.h
-    # multi_ls_state.h
+    multi_ls_state.h
     # uni_lin_reg_ls_state.h
     # fa_state.h
 )

--- a/src/hierarchies/likelihoods/states/CMakeLists.txt
+++ b/src/hierarchies/likelihoods/states/CMakeLists.txt
@@ -1,7 +1,8 @@
 target_sources(bayesmix PUBLIC
     includes.h
+    base_state.h
     uni_ls_state.h
-    multi_ls_state.h
-    uni_lin_reg_ls_state.h
-    fa_state.h
+    # multi_ls_state.h
+    # uni_lin_reg_ls_state.h
+    # fa_state.h
 )

--- a/src/hierarchies/likelihoods/states/base_state.h
+++ b/src/hierarchies/likelihoods/states/base_state.h
@@ -21,7 +21,7 @@ class BaseState {
 
   virtual void set_from_proto(const ProtoState &state_, bool update_card) = 0;
 
-  virtual ProtoState get_as_proto() = 0;
+  virtual ProtoState get_as_proto() const = 0;
 
   std::shared_ptr<ProtoState> to_proto() {
     return std::make_shared<ProtoState>(get_as_proto());

--- a/src/hierarchies/likelihoods/states/base_state.h
+++ b/src/hierarchies/likelihoods/states/base_state.h
@@ -1,0 +1,35 @@
+#ifndef BAYESMIX_HIERARCHIES_LIKELIHOODS_STATES_BASE_STATE_H_
+#define BAYESMIX_HIERARCHIES_LIKELIHOODS_STATES_BASE_STATE_H_
+
+#include <memory>
+#include <stan/math/rev.hpp>
+
+#include "algorithm_state.pb.h"
+#include "src/utils/proto_utils.h"
+
+namespace States {
+
+class BaseState {
+ public:
+  int card;
+  
+  using ProtoState = bayesmix::AlgorithmState::ClusterState;
+
+  virtual Eigen::VectorXd get_unconstrained() { return Eigen::VectorXd(0); }
+
+  virtual void set_from_unconstrained(Eigen::VectorXd in) { }
+
+  virtual void set_from_proto(const ProtoState &state_, bool update_card) = 0;
+
+  virtual ProtoState get_as_proto() = 0;
+
+  std::shared_ptr<ProtoState> to_proto() {
+    return std::make_shared<ProtoState>(get_as_proto());
+  }
+
+  virtual double log_det_jac() { return -1; }
+};
+
+}  // namespace States
+
+#endif  // BAYESMIX_HIERARCHIES_LIKELIHOODS_STATES_BASE_STATE_H_

--- a/src/hierarchies/likelihoods/states/base_state.h
+++ b/src/hierarchies/likelihoods/states/base_state.h
@@ -17,13 +17,13 @@ class BaseState {
 
   virtual Eigen::VectorXd get_unconstrained() { return Eigen::VectorXd(0); }
 
-  virtual void set_from_unconstrained(Eigen::VectorXd in) {}
+  virtual void set_from_unconstrained(const Eigen::VectorXd &in) {}
 
   virtual void set_from_proto(const ProtoState &state_, bool update_card) = 0;
 
   virtual ProtoState get_as_proto() const = 0;
 
-  std::shared_ptr<ProtoState> to_proto() {
+  std::shared_ptr<ProtoState> to_proto() const {
     return std::make_shared<ProtoState>(get_as_proto());
   }
 

--- a/src/hierarchies/likelihoods/states/base_state.h
+++ b/src/hierarchies/likelihoods/states/base_state.h
@@ -7,17 +7,17 @@
 #include "algorithm_state.pb.h"
 #include "src/utils/proto_utils.h"
 
-namespace States {
+namespace State {
 
 class BaseState {
  public:
   int card;
-  
+
   using ProtoState = bayesmix::AlgorithmState::ClusterState;
 
   virtual Eigen::VectorXd get_unconstrained() { return Eigen::VectorXd(0); }
 
-  virtual void set_from_unconstrained(Eigen::VectorXd in) { }
+  virtual void set_from_unconstrained(Eigen::VectorXd in) {}
 
   virtual void set_from_proto(const ProtoState &state_, bool update_card) = 0;
 
@@ -30,6 +30,6 @@ class BaseState {
   virtual double log_det_jac() { return -1; }
 };
 
-}  // namespace States
+}  // namespace State
 
 #endif  // BAYESMIX_HIERARCHIES_LIKELIHOODS_STATES_BASE_STATE_H_

--- a/src/hierarchies/likelihoods/states/fa_state.h
+++ b/src/hierarchies/likelihoods/states/fa_state.h
@@ -5,17 +5,53 @@
 #include <tuple>
 
 #include "algorithm_state.pb.h"
+#include "base_state.h"
+#include "src/utils/distributions.h"
 #include "src/utils/eigen_utils.h"
 #include "src/utils/proto_utils.h"
 
 namespace State {
 
-class FA {
+class FA : public BaseState {
  public:
   Eigen::VectorXd mu, psi;
   Eigen::MatrixXd eta, lambda, cov_wood;
   Eigen::DiagonalMatrix<double, Eigen::Dynamic> psi_inverse;
   double cov_logdet;
+
+  using ProtoState = bayesmix::AlgorithmState::ClusterState;
+
+  void set_from_proto(const ProtoState &state_, bool update_card) override {
+    if (update_card) {
+      card = state_.cardinality();
+    }
+
+    mu = bayesmix::to_eigen(state_.fa_state().mu());
+    psi = bayesmix::to_eigen(state_.fa_state().psi());
+    eta = bayesmix::to_eigen(state_.fa_state().eta());
+    lambda = bayesmix::to_eigen(state_.fa_state().lambda());
+    psi_inverse = psi.cwiseInverse().asDiagonal();
+    compute_wood_factors();
+  }
+
+  void compute_wood_factors() {
+    auto [cov_wood_, cov_logdet_] =
+        bayesmix::compute_wood_chol_and_logdet(psi_inverse, lambda);
+    cov_logdet = cov_logdet_;
+    cov_wood = cov_wood_;
+  }
+
+  ProtoState get_as_proto() const override {
+    bayesmix::FAState state_;
+    bayesmix::to_proto(mu, state_.mutable_mu());
+    bayesmix::to_proto(psi, state_.mutable_psi());
+    bayesmix::to_proto(eta, state_.mutable_eta());
+    bayesmix::to_proto(lambda, state_.mutable_lambda());
+
+    bayesmix::AlgorithmState::ClusterState out;
+    out.mutable_fa_state()->CopyFrom(state_);
+    return out;
+  }
 };
 
 }  // namespace State

--- a/src/hierarchies/likelihoods/states/multi_ls_state.h
+++ b/src/hierarchies/likelihoods/states/multi_ls_state.h
@@ -57,7 +57,7 @@ class MultiLS : public BaseState {
     return multi_ls_to_unconstrained(mean, prec);
   }
 
-  void set_from_unconstrained(Eigen::VectorXd in) override {
+  void set_from_unconstrained(const Eigen::VectorXd &in) override {
     std::tie(mean, prec) = multi_ls_to_constrained(in);
     set_from_constrained(mean, prec);
   }

--- a/src/hierarchies/likelihoods/states/uni_lin_reg_ls_state.h
+++ b/src/hierarchies/likelihoods/states/uni_lin_reg_ls_state.h
@@ -50,7 +50,7 @@ class UniLinRegLS : public BaseState {
     return uni_lin_reg_to_unconstrained(temp);
   }
 
-  void set_from_unconstrained(Eigen::VectorXd in) override {
+  void set_from_unconstrained(const Eigen::VectorXd &in) override {
     Eigen::VectorXd temp = uni_lin_reg_to_constrained(in);
     int dim = in.size() - 1;
     regression_coeffs = temp.head(dim);

--- a/src/hierarchies/likelihoods/states/uni_ls_state.h
+++ b/src/hierarchies/likelihoods/states/uni_ls_state.h
@@ -45,7 +45,7 @@ class UniLS : public BaseState {
     return uni_ls_to_unconstrained(temp);
   }
 
-  void set_from_unconstrained(Eigen::VectorXd in) override {
+  void set_from_unconstrained(const Eigen::VectorXd &in) override {
     Eigen::VectorXd temp = uni_ls_to_constrained(in);
     mean = temp(0);
     var = temp(1);

--- a/src/hierarchies/likelihoods/states/uni_ls_state.h
+++ b/src/hierarchies/likelihoods/states/uni_ls_state.h
@@ -5,8 +5,8 @@
 #include <stan/math/rev.hpp>
 
 #include "algorithm_state.pb.h"
-#include "src/utils/proto_utils.h"
 #include "base_state.h"
+#include "src/utils/proto_utils.h"
 
 namespace State {
 
@@ -33,7 +33,7 @@ T uni_ls_log_det_jac(Eigen::Matrix<T, Eigen::Dynamic, 1> constrained) {
   return out;
 }
 
-class UniLS: public BaseState {
+class UniLS : public BaseState {
  public:
   double mean, var;
 
@@ -59,7 +59,7 @@ class UniLS: public BaseState {
     var = state_.uni_ls_state().var();
   }
 
-  ProtoState get_as_proto() override {
+  ProtoState get_as_proto() const override {
     ProtoState state;
     state.mutable_uni_ls_state()->set_mean(mean);
     state.mutable_uni_ls_state()->set_var(var);

--- a/src/hierarchies/likelihoods/uni_lin_reg_likelihood.cc
+++ b/src/hierarchies/likelihoods/uni_lin_reg_likelihood.cc
@@ -2,30 +2,10 @@
 
 #include "src/utils/eigen_utils.h"
 
-void UniLinRegLikelihood::set_state_from_proto(
-    const google::protobuf::Message &state_, bool update_card) {
-  auto &statecast = downcast_state(state_);
-  state.regression_coeffs =
-      bayesmix::to_eigen(statecast.lin_reg_uni_ls_state().regression_coeffs());
-  state.var = statecast.lin_reg_uni_ls_state().var();
-  if (update_card) set_card(statecast.cardinality());
-}
-
 void UniLinRegLikelihood::clear_summary_statistics() {
   mixed_prod = Eigen::VectorXd::Zero(dim);
   data_sum_squares = 0.0;
   covar_sum_squares = Eigen::MatrixXd::Zero(dim, dim);
-}
-
-std::shared_ptr<bayesmix::AlgorithmState::ClusterState>
-UniLinRegLikelihood::get_state_proto() const {
-  bayesmix::LinRegUniLSState state_;
-  bayesmix::to_proto(state.regression_coeffs,
-                     state_.mutable_regression_coeffs());
-  state_.set_var(state.var);
-  auto out = std::make_shared<bayesmix::AlgorithmState::ClusterState>();
-  out->mutable_lin_reg_uni_ls_state()->CopyFrom(state_);
-  return out;
 }
 
 double UniLinRegLikelihood::compute_lpdf(

--- a/src/hierarchies/likelihoods/uni_lin_reg_likelihood.h
+++ b/src/hierarchies/likelihoods/uni_lin_reg_likelihood.h
@@ -18,8 +18,6 @@ class UniLinRegLikelihood
   ~UniLinRegLikelihood() = default;
   bool is_multivariate() const override { return false; };
   bool is_dependent() const override { return true; };
-  void set_state_from_proto(const google::protobuf::Message &state_,
-                            bool update_card = true) override;
   void clear_summary_statistics() override;
 
   // Getters and Setters
@@ -31,9 +29,6 @@ class UniLinRegLikelihood
   double get_data_sum_squares() const { return data_sum_squares; };
   Eigen::MatrixXd get_covar_sum_squares() const { return covar_sum_squares; };
   Eigen::VectorXd get_mixed_prod() const { return mixed_prod; };
-
-  std::shared_ptr<bayesmix::AlgorithmState::ClusterState> get_state_proto()
-      const override;
 
  protected:
   double compute_lpdf(const Eigen::RowVectorXd &datum,

--- a/src/hierarchies/likelihoods/uni_norm_likelihood.cc
+++ b/src/hierarchies/likelihoods/uni_norm_likelihood.cc
@@ -23,6 +23,19 @@ void UniNormLikelihood::set_state_from_proto(
   if (update_card) set_card(statecast.cardinality());
 }
 
+void UniNormLikelihood::set_state(
+    const States::UniLS &state_, bool update_card) {
+  
+  int old_card;
+  if (! update_card) {
+    old_card = state.card;
+  }
+  state = state_;
+  if (! update_card) {
+    state.card = old_card;
+  }
+}
+
 std::shared_ptr<bayesmix::AlgorithmState::ClusterState>
 UniNormLikelihood::get_state_proto() const {
   auto out = std::make_shared<bayesmix::AlgorithmState::ClusterState>();

--- a/src/hierarchies/likelihoods/uni_norm_likelihood.cc
+++ b/src/hierarchies/likelihoods/uni_norm_likelihood.cc
@@ -15,27 +15,6 @@ void UniNormLikelihood::update_sum_stats(const Eigen::RowVectorXd &datum,
   }
 }
 
-void UniNormLikelihood::set_state_from_proto(
-    const google::protobuf::Message &state_, bool update_card) {
-  auto &statecast = downcast_state(state_);
-  state.mean = statecast.uni_ls_state().mean();
-  state.var = statecast.uni_ls_state().var();
-  if (update_card) set_card(statecast.cardinality());
-}
-
-void UniNormLikelihood::set_state(
-    const States::UniLS &state_, bool update_card) {
-  
-  int old_card;
-  if (! update_card) {
-    old_card = state.card;
-  }
-  state = state_;
-  if (! update_card) {
-    state.card = old_card;
-  }
-}
-
 std::shared_ptr<bayesmix::AlgorithmState::ClusterState>
 UniNormLikelihood::get_state_proto() const {
   auto out = std::make_shared<bayesmix::AlgorithmState::ClusterState>();

--- a/src/hierarchies/likelihoods/uni_norm_likelihood.cc
+++ b/src/hierarchies/likelihoods/uni_norm_likelihood.cc
@@ -15,14 +15,6 @@ void UniNormLikelihood::update_sum_stats(const Eigen::RowVectorXd &datum,
   }
 }
 
-std::shared_ptr<bayesmix::AlgorithmState::ClusterState>
-UniNormLikelihood::get_state_proto() const {
-  auto out = std::make_shared<bayesmix::AlgorithmState::ClusterState>();
-  out->mutable_uni_ls_state()->set_mean(state.mean);
-  out->mutable_uni_ls_state()->set_var(state.var);
-  return out;
-}
-
 void UniNormLikelihood::clear_summary_statistics() {
   data_sum = 0;
   data_sum_squares = 0;

--- a/src/hierarchies/likelihoods/uni_norm_likelihood.h
+++ b/src/hierarchies/likelihoods/uni_norm_likelihood.h
@@ -18,9 +18,6 @@ class UniNormLikelihood
   ~UniNormLikelihood() = default;
   bool is_multivariate() const override { return false; };
   bool is_dependent() const override { return false; };
-  void set_state_from_proto(const google::protobuf::Message &state_,
-                            bool update_card = true) override;
-  void set_state(const States::UniLS &state_, bool update_card = true);
   void clear_summary_statistics() override;
   double get_data_sum() const { return data_sum; };
   double get_data_sum_squares() const { return data_sum_squares; };

--- a/src/hierarchies/likelihoods/uni_norm_likelihood.h
+++ b/src/hierarchies/likelihoods/uni_norm_likelihood.h
@@ -34,9 +34,6 @@ class UniNormLikelihood
     return out;
   }
 
-  std::shared_ptr<bayesmix::AlgorithmState::ClusterState> get_state_proto()
-      const override;
-
  protected:
   double compute_lpdf(const Eigen::RowVectorXd &datum) const override;
   void update_sum_stats(const Eigen::RowVectorXd &datum, bool add) override;

--- a/src/hierarchies/likelihoods/uni_norm_likelihood.h
+++ b/src/hierarchies/likelihoods/uni_norm_likelihood.h
@@ -12,7 +12,7 @@
 #include "states/includes.h"
 
 class UniNormLikelihood
-    : public BaseLikelihood<UniNormLikelihood, State::UniLS> {
+    : public BaseLikelihood<UniNormLikelihood, States::UniLS> {
  public:
   UniNormLikelihood() = default;
   ~UniNormLikelihood() = default;
@@ -20,6 +20,7 @@ class UniNormLikelihood
   bool is_dependent() const override { return false; };
   void set_state_from_proto(const google::protobuf::Message &state_,
                             bool update_card = true) override;
+  void set_state(const States::UniLS &state_, bool update_card = true);
   void clear_summary_statistics() override;
   double get_data_sum() const { return data_sum; };
   double get_data_sum_squares() const { return data_sum_squares; };

--- a/src/hierarchies/likelihoods/uni_norm_likelihood.h
+++ b/src/hierarchies/likelihoods/uni_norm_likelihood.h
@@ -12,7 +12,7 @@
 #include "states/includes.h"
 
 class UniNormLikelihood
-    : public BaseLikelihood<UniNormLikelihood, States::UniLS> {
+    : public BaseLikelihood<UniNormLikelihood, State::UniLS> {
  public:
   UniNormLikelihood() = default;
   ~UniNormLikelihood() = default;

--- a/src/hierarchies/priors/abstract_prior_model.h
+++ b/src/hierarchies/priors/abstract_prior_model.h
@@ -68,10 +68,7 @@ class AbstractPriorModel {
   //! parameters to use for the sampling. The default behaviour (i.e.
   //! `hier_hypers = nullptr`) uses prior hyperparameters
   //! @return A Protobuf message storing the state sampled from the prior model
-  // virtual std::shared_ptr<google::protobuf::Message> sample(
-  //   bool use_post_hypers) = 0;
-
-  virtual std::shared_ptr<google::protobuf::Message> sample(
+  virtual std::shared_ptr<google::protobuf::Message> sample_proto(
       ProtoHypersPtr hier_hypers = nullptr) = 0;
 
   //! Updates hyperparameter values given a vector of cluster states

--- a/src/hierarchies/priors/base_prior_model.h
+++ b/src/hierarchies/priors/base_prior_model.h
@@ -57,8 +57,8 @@ class BasePriorModel : public AbstractPriorModel {
   virtual State sample(ProtoHypersPtr hier_hypers = nullptr) = 0;
 
   std::shared_ptr<google::protobuf::Message> sample_proto(
-       ProtoHypersPtr hier_hypers = nullptr) override {
-     return sample(hier_hypers).to_proto();
+      ProtoHypersPtr hier_hypers = nullptr) override {
+    return sample(hier_hypers).to_proto();
   }
 
   //! Returns an independent, data-less copy of this object
@@ -120,14 +120,14 @@ class BasePriorModel : public AbstractPriorModel {
 };
 
 /* *** Methods Definitions *** */
-template<class Derived, class State, typename HyperParams, typename Prior>
+template <class Derived, class State, typename HyperParams, typename Prior>
 std::shared_ptr<AbstractPriorModel>
 BasePriorModel<Derived, State, HyperParams, Prior>::clone() const {
   auto out = std::make_shared<Derived>(static_cast<Derived const &>(*this));
   return out;
 }
 
-template<class Derived, class State, typename HyperParams, typename Prior>
+template <class Derived, class State, typename HyperParams, typename Prior>
 std::shared_ptr<AbstractPriorModel>
 BasePriorModel<Derived, State, HyperParams, Prior>::deep_clone() const {
   auto out = std::make_shared<Derived>(static_cast<Derived const &>(*this));
@@ -149,7 +149,7 @@ BasePriorModel<Derived, State, HyperParams, Prior>::deep_clone() const {
   return out;
 }
 
-template<class Derived, class State, typename HyperParams, typename Prior>
+template <class Derived, class State, typename HyperParams, typename Prior>
 google::protobuf::Message *
 BasePriorModel<Derived, State, HyperParams, Prior>::get_mutable_prior() {
   if (prior == nullptr) {
@@ -158,7 +158,7 @@ BasePriorModel<Derived, State, HyperParams, Prior>::get_mutable_prior() {
   return prior.get();
 }
 
-template<class Derived, class State, typename HyperParams, typename Prior>
+template <class Derived, class State, typename HyperParams, typename Prior>
 void BasePriorModel<Derived, State, HyperParams, Prior>::write_hypers_to_proto(
     google::protobuf::Message *out) const {
   std::shared_ptr<bayesmix::AlgorithmState::HierarchyHypers> hypers_ =
@@ -167,15 +167,16 @@ void BasePriorModel<Derived, State, HyperParams, Prior>::write_hypers_to_proto(
   out_cast->CopyFrom(*hypers_.get());
 }
 
-template<class Derived, class State, typename HyperParams, typename Prior>
+template <class Derived, class State, typename HyperParams, typename Prior>
 void BasePriorModel<Derived, State, HyperParams, Prior>::initialize() {
   check_prior_is_set();
   create_empty_hypers();
   initialize_hypers();
 }
 
-template<class Derived, class State, typename HyperParams, typename Prior>
-void BasePriorModel<Derived, State, HyperParams, Prior>::check_prior_is_set() const {
+template <class Derived, class State, typename HyperParams, typename Prior>
+void BasePriorModel<Derived, State, HyperParams, Prior>::check_prior_is_set()
+    const {
   if (prior == nullptr) {
     throw std::invalid_argument("Hierarchy prior was not provided");
   }

--- a/src/hierarchies/priors/fa_prior_model.cc
+++ b/src/hierarchies/priors/fa_prior_model.cc
@@ -29,8 +29,7 @@ double FAPriorModel::lpdf(const google::protobuf::Message &state_) {
   return target;
 }
 
-std::shared_ptr<google::protobuf::Message> FAPriorModel::sample(
-    ProtoHypersPtr hier_hypers) {
+State::FA FAPriorModel::sample(ProtoHypersPtr hier_hypers) {
   // Random seed
   auto &rng = bayesmix::Rng::Instance().get();
 
@@ -53,13 +52,7 @@ std::shared_ptr<google::protobuf::Message> FAPriorModel::sample(
       out.lambda(j, i) = stan::math::normal_rng(0, 1, rng);
     }
   }
-
-  // Eigen2Proto conversion
-  bayesmix::AlgorithmState::ClusterState state;
-  bayesmix::to_proto(out.mu, state.mutable_fa_state()->mutable_mu());
-  bayesmix::to_proto(out.psi, state.mutable_fa_state()->mutable_psi());
-  bayesmix::to_proto(out.lambda, state.mutable_fa_state()->mutable_lambda());
-  return std::make_shared<bayesmix::AlgorithmState::ClusterState>(state);
+  return out;
 }
 
 void FAPriorModel::update_hypers(

--- a/src/hierarchies/priors/fa_prior_model.h
+++ b/src/hierarchies/priors/fa_prior_model.h
@@ -11,7 +11,8 @@
 #include "src/utils/rng.h"
 
 class FAPriorModel
-    : public BasePriorModel<FAPriorModel, Hyperparams::FA, bayesmix::FAPrior> {
+    : public BasePriorModel<FAPriorModel, State::FA, Hyperparams::FA,
+                            bayesmix::FAPrior> {
  public:
   using AbstractPriorModel::ProtoHypers;
   using AbstractPriorModel::ProtoHypersPtr;
@@ -21,8 +22,7 @@ class FAPriorModel
 
   double lpdf(const google::protobuf::Message &state_) override;
 
-  std::shared_ptr<google::protobuf::Message> sample(
-      ProtoHypersPtr hier_hypers = nullptr) override;
+  State::FA sample(ProtoHypersPtr hier_hypers = nullptr) override;
 
   void update_hypers(const std::vector<bayesmix::AlgorithmState::ClusterState>
                          &states) override;

--- a/src/hierarchies/priors/mnig_prior_model.cc
+++ b/src/hierarchies/priors/mnig_prior_model.cc
@@ -11,8 +11,7 @@ double MNIGPriorModel::lpdf(const google::protobuf::Message &state_) {
   return target;
 }
 
-std::shared_ptr<google::protobuf::Message> MNIGPriorModel::sample(
-    ProtoHypersPtr hier_hypers) {
+State::UniLinRegLS MNIGPriorModel::sample(ProtoHypersPtr hier_hypers) {
   auto &rng = bayesmix::Rng::Instance().get();
   auto params = (hier_hypers) ? hier_hypers->lin_reg_uni_state()
                               : get_hypers_proto()->lin_reg_uni_state();
@@ -23,7 +22,7 @@ std::shared_ptr<google::protobuf::Message> MNIGPriorModel::sample(
   out.var = stan::math::inv_gamma_rng(params.shape(), params.scale(), rng);
   out.regression_coeffs =
       stan::math::multi_normal_prec_rng(mean, var_scaling / out.var, rng);
-  return out.to_proto();
+  return out;
 }
 
 void MNIGPriorModel::update_hypers(

--- a/src/hierarchies/priors/mnig_prior_model.h
+++ b/src/hierarchies/priors/mnig_prior_model.h
@@ -10,8 +10,9 @@
 #include "hyperparams.h"
 #include "src/utils/rng.h"
 
-class MNIGPriorModel : public BasePriorModel<MNIGPriorModel, Hyperparams::MNIG,
-                                             bayesmix::LinRegUniPrior> {
+class MNIGPriorModel
+    : public BasePriorModel<MNIGPriorModel, State::UniLinRegLS,
+                            Hyperparams::MNIG, bayesmix::LinRegUniPrior> {
  public:
   using AbstractPriorModel::ProtoHypers;
   using AbstractPriorModel::ProtoHypersPtr;
@@ -21,8 +22,7 @@ class MNIGPriorModel : public BasePriorModel<MNIGPriorModel, Hyperparams::MNIG,
 
   double lpdf(const google::protobuf::Message &state_) override;
 
-  std::shared_ptr<google::protobuf::Message> sample(
-      ProtoHypersPtr hier_hypers = nullptr) override;
+  State::UniLinRegLS sample(ProtoHypersPtr hier_hypers = nullptr) override;
 
   void update_hypers(const std::vector<bayesmix::AlgorithmState::ClusterState>
                          &states) override;

--- a/src/hierarchies/priors/nig_prior_model.cc
+++ b/src/hierarchies/priors/nig_prior_model.cc
@@ -84,17 +84,17 @@ double NIGPriorModel::lpdf(const google::protobuf::Message &state_) {
   return target;
 }
 
-std::shared_ptr<google::protobuf::Message> NIGPriorModel::sample(
+States::UniLS NIGPriorModel::sample(
     ProtoHypersPtr hier_hypers) {
   auto &rng = bayesmix::Rng::Instance().get();
   auto params = (hier_hypers) ? hier_hypers->nnig_state()
                               : get_hypers_proto()->nnig_state();
 
-  State::UniLS out;
+  States::UniLS out;
   out.var = stan::math::inv_gamma_rng(params.shape(), params.scale(), rng);
   out.mean = stan::math::normal_rng(params.mean(),
                                     sqrt(out.var / params.var_scaling()), rng);
-  return out.to_proto();
+  return out;
 }
 
 void NIGPriorModel::update_hypers(

--- a/src/hierarchies/priors/nig_prior_model.cc
+++ b/src/hierarchies/priors/nig_prior_model.cc
@@ -84,13 +84,12 @@ double NIGPriorModel::lpdf(const google::protobuf::Message &state_) {
   return target;
 }
 
-States::UniLS NIGPriorModel::sample(
-    ProtoHypersPtr hier_hypers) {
+State::UniLS NIGPriorModel::sample(ProtoHypersPtr hier_hypers) {
   auto &rng = bayesmix::Rng::Instance().get();
   auto params = (hier_hypers) ? hier_hypers->nnig_state()
                               : get_hypers_proto()->nnig_state();
 
-  States::UniLS out;
+  State::UniLS out;
   out.var = stan::math::inv_gamma_rng(params.shape(), params.scale(), rng);
   out.mean = stan::math::normal_rng(params.mean(),
                                     sqrt(out.var / params.var_scaling()), rng);

--- a/src/hierarchies/priors/nig_prior_model.h
+++ b/src/hierarchies/priors/nig_prior_model.h
@@ -11,8 +11,9 @@
 #include "hyperparams.h"
 #include "src/utils/rng.h"
 
-class NIGPriorModel : public BasePriorModel<NIGPriorModel, Hyperparams::NIG,
-                                            bayesmix::NNIGPrior> {
+class NIGPriorModel
+    : public BasePriorModel<NIGPriorModel, States::UniLS, Hyperparams::NIG,
+                            bayesmix::NNIGPrior> {
  public:
   using AbstractPriorModel::ProtoHypers;
   using AbstractPriorModel::ProtoHypersPtr;
@@ -26,8 +27,8 @@ class NIGPriorModel : public BasePriorModel<NIGPriorModel, Hyperparams::NIG,
   T lpdf_from_unconstrained(
       const Eigen::Matrix<T, Eigen::Dynamic, 1> &unconstrained_params) const {
     Eigen::Matrix<T, Eigen::Dynamic, 1> constrained_params =
-        State::uni_ls_to_constrained(unconstrained_params);
-    T log_det_jac = State::uni_ls_log_det_jac(constrained_params);
+        States::uni_ls_to_constrained(unconstrained_params);
+    T log_det_jac = States::uni_ls_log_det_jac(constrained_params);
     T mean = constrained_params(0);
     T var = constrained_params(1);
     T lpdf = stan::math::normal_lpdf(mean, hypers->mean,
@@ -37,8 +38,7 @@ class NIGPriorModel : public BasePriorModel<NIGPriorModel, Hyperparams::NIG,
     return lpdf + log_det_jac;
   }
 
-  std::shared_ptr<google::protobuf::Message> sample(
-      ProtoHypersPtr hier_hypers = nullptr) override;
+  States::UniLS sample(ProtoHypersPtr hier_hypers = nullptr) override;
 
   void update_hypers(const std::vector<bayesmix::AlgorithmState::ClusterState>
                          &states) override;

--- a/src/hierarchies/priors/nig_prior_model.h
+++ b/src/hierarchies/priors/nig_prior_model.h
@@ -12,7 +12,7 @@
 #include "src/utils/rng.h"
 
 class NIGPriorModel
-    : public BasePriorModel<NIGPriorModel, States::UniLS, Hyperparams::NIG,
+    : public BasePriorModel<NIGPriorModel, State::UniLS, Hyperparams::NIG,
                             bayesmix::NNIGPrior> {
  public:
   using AbstractPriorModel::ProtoHypers;
@@ -27,8 +27,8 @@ class NIGPriorModel
   T lpdf_from_unconstrained(
       const Eigen::Matrix<T, Eigen::Dynamic, 1> &unconstrained_params) const {
     Eigen::Matrix<T, Eigen::Dynamic, 1> constrained_params =
-        States::uni_ls_to_constrained(unconstrained_params);
-    T log_det_jac = States::uni_ls_log_det_jac(constrained_params);
+        State::uni_ls_to_constrained(unconstrained_params);
+    T log_det_jac = State::uni_ls_log_det_jac(constrained_params);
     T mean = constrained_params(0);
     T var = constrained_params(1);
     T lpdf = stan::math::normal_lpdf(mean, hypers->mean,
@@ -38,7 +38,7 @@ class NIGPriorModel
     return lpdf + log_det_jac;
   }
 
-  States::UniLS sample(ProtoHypersPtr hier_hypers = nullptr) override;
+  State::UniLS sample(ProtoHypersPtr hier_hypers = nullptr) override;
 
   void update_hypers(const std::vector<bayesmix::AlgorithmState::ClusterState>
                          &states) override;

--- a/src/hierarchies/priors/nw_prior_model.cc
+++ b/src/hierarchies/priors/nw_prior_model.cc
@@ -121,8 +121,7 @@ double NWPriorModel::lpdf(const google::protobuf::Message &state_) {
   return target;
 }
 
-std::shared_ptr<google::protobuf::Message> NWPriorModel::sample(
-    ProtoHypersPtr hier_hypers) {
+State::MultiLS NWPriorModel::sample(ProtoHypersPtr hier_hypers) {
   auto &rng = bayesmix::Rng::Instance().get();
   auto params = (hier_hypers) ? hier_hypers->nnw_state()
                               : get_hypers_proto()->nnw_state();
@@ -137,7 +136,7 @@ std::shared_ptr<google::protobuf::Message> NWPriorModel::sample(
   out.mean = stan::math::multi_normal_prec_rng(
       mean, tau_new * params.var_scaling(), rng);
   write_prec_to_state(tau_new, &out);
-  return out.to_proto();
+  return out;
 };
 
 void NWPriorModel::update_hypers(

--- a/src/hierarchies/priors/nw_prior_model.h
+++ b/src/hierarchies/priors/nw_prior_model.h
@@ -11,16 +11,16 @@
 #include "hyperparams.h"
 #include "src/utils/rng.h"
 
-class NWPriorModel : public BasePriorModel<NWPriorModel, Hyperparams::NW,
-                                           bayesmix::NNWPrior> {
+class NWPriorModel
+    : public BasePriorModel<NWPriorModel, State::MultiLS, Hyperparams::NW,
+                            bayesmix::NNWPrior> {
  public:
   NWPriorModel() = default;
   ~NWPriorModel() = default;
 
   double lpdf(const google::protobuf::Message &state_) override;
 
-  std::shared_ptr<google::protobuf::Message> sample(
-      ProtoHypersPtr hier_hypers = nullptr) override;
+  State::MultiLS sample(ProtoHypersPtr hier_hypers = nullptr) override;
 
   void update_hypers(const std::vector<bayesmix::AlgorithmState::ClusterState>
                          &states) override;

--- a/src/hierarchies/priors/nxig_prior_model.cc
+++ b/src/hierarchies/priors/nxig_prior_model.cc
@@ -30,8 +30,7 @@ double NxIGPriorModel::lpdf(const google::protobuf::Message &state_) {
   return target;
 }
 
-std::shared_ptr<google::protobuf::Message> NxIGPriorModel::sample(
-    ProtoHypersPtr hier_hypers) {
+State::UniLS NxIGPriorModel::sample(ProtoHypersPtr hier_hypers) {
   auto &rng = bayesmix::Rng::Instance().get();
   auto params = (hier_hypers) ? hier_hypers->nnxig_state()
                               : get_hypers_proto()->nnxig_state();
@@ -39,7 +38,7 @@ std::shared_ptr<google::protobuf::Message> NxIGPriorModel::sample(
   State::UniLS out;
   out.mean = stan::math::normal_rng(params.mean(), sqrt(params.var()), rng);
   out.var = stan::math::inv_gamma_rng(params.shape(), params.scale(), rng);
-  return out.to_proto();
+  return out;
 };
 
 void NxIGPriorModel::update_hypers(

--- a/src/hierarchies/priors/nxig_prior_model.h
+++ b/src/hierarchies/priors/nxig_prior_model.h
@@ -11,8 +11,9 @@
 #include "hyperparams.h"
 #include "src/utils/rng.h"
 
-class NxIGPriorModel : public BasePriorModel<NxIGPriorModel, Hyperparams::NxIG,
-                                             bayesmix::NNxIGPrior> {
+class NxIGPriorModel
+    : public BasePriorModel<NxIGPriorModel, State::UniLS, Hyperparams::NxIG,
+                            bayesmix::NNxIGPrior> {
  public:
   using AbstractPriorModel::ProtoHypers;
   using AbstractPriorModel::ProtoHypersPtr;
@@ -22,8 +23,7 @@ class NxIGPriorModel : public BasePriorModel<NxIGPriorModel, Hyperparams::NxIG,
 
   double lpdf(const google::protobuf::Message &state_) override;
 
-  std::shared_ptr<google::protobuf::Message> sample(
-      ProtoHypersPtr hier_hypers = nullptr) override;
+  State::UniLS sample(ProtoHypersPtr hier_hypers = nullptr) override;
 
   void update_hypers(const std::vector<bayesmix::AlgorithmState::ClusterState>
                          &states) override;

--- a/src/hierarchies/updaters/fa_updater.cc
+++ b/src/hierarchies/updaters/fa_updater.cc
@@ -10,7 +10,7 @@ void FAUpdater::draw(AbstractLikelihood& like, AbstractPriorModel& prior,
   // Sample from the full conditional of the fa hierarchy
   bool set_card = true, use_post_hypers = true;
   if (likecast.get_card() == 0) {
-    likecast.set_state_from_proto(*priorcast.sample(), !set_card);
+    likecast.set_state(priorcast.sample(), !set_card);
   } else {
     // Get state and hypers
     State::FA new_state = likecast.get_state();
@@ -20,17 +20,7 @@ void FAUpdater::draw(AbstractLikelihood& like, AbstractPriorModel& prior,
     sample_mu(new_state, hypers, likecast);
     sample_psi(new_state, hypers, likecast);
     sample_lambda(new_state, hypers, likecast);
-    // Eigen2Proto conversion
-    bayesmix::AlgorithmState::ClusterState new_state_proto;
-    bayesmix::to_proto(new_state.eta,
-                       new_state_proto.mutable_fa_state()->mutable_eta());
-    bayesmix::to_proto(new_state.mu,
-                       new_state_proto.mutable_fa_state()->mutable_mu());
-    bayesmix::to_proto(new_state.psi,
-                       new_state_proto.mutable_fa_state()->mutable_psi());
-    bayesmix::to_proto(new_state.lambda,
-                       new_state_proto.mutable_fa_state()->mutable_lambda());
-    likecast.set_state_from_proto(new_state_proto, !set_card);
+    likecast.set_state(new_state, !set_card);
   }
 }
 

--- a/src/hierarchies/updaters/semi_conjugate_updater.h
+++ b/src/hierarchies/updaters/semi_conjugate_updater.h
@@ -47,10 +47,10 @@ void SemiConjugateUpdater<Likelihood, PriorModel>::draw(
   // Sample from the full conditional of a semi-conjugate hierarchy
   bool set_card = true; /*, use_post_hypers=true;*/
   if (likecast.get_card() == 0) {
-    likecast.set_state_from_proto(*priorcast.sample(), !set_card);
+    likecast.set_state(priorcast.sample(), !set_card);
   } else {
     auto post_params = compute_posterior_hypers(likecast, priorcast);
-    likecast.set_state_from_proto(*priorcast.sample(post_params), !set_card);
+    likecast.set_state(priorcast.sample(post_params), !set_card);
     if (update_params) save_posterior_hypers(post_params);
   }
 }

--- a/src/utils/testing_utils.cc
+++ b/src/utils/testing_utils.cc
@@ -57,7 +57,7 @@ std::shared_ptr<BaseAlgorithm> get_algorithm(const std::string& id, int dim) {
   if (dim == 1) {
     hier = get_univariate_nnig_hierarchy();
   } else {
-    // hier = get_multivariate_nnw_hierarchy(dim);
+    hier = get_multivariate_nnw_hierarchy(dim);
   }
   hier->initialize();
   algo->set_mixing(mixing);

--- a/src/utils/testing_utils.cc
+++ b/src/utils/testing_utils.cc
@@ -57,7 +57,7 @@ std::shared_ptr<BaseAlgorithm> get_algorithm(const std::string& id, int dim) {
   if (dim == 1) {
     hier = get_univariate_nnig_hierarchy();
   } else {
-    hier = get_multivariate_nnw_hierarchy(dim);
+    // hier = get_multivariate_nnw_hierarchy(dim);
   }
   hier->initialize();
   algo->set_mixing(mixing);

--- a/test/prior_models.cc
+++ b/test/prior_models.cc
@@ -125,7 +125,8 @@ TEST(nig_prior_model, sample) {
   auto state2 = prior->sample();
 
   // Check if they coincides
-  ASSERT_TRUE(state1->DebugString() != state2->DebugString());
+  ASSERT_TRUE(state1.get_as_proto().DebugString() !=
+              state2.get_as_proto().DebugString());
 }
 
 TEST(nxig_prior_model, set_get_hypers) {
@@ -207,7 +208,8 @@ TEST(nxig_prior_model, sample) {
   auto state2 = prior->sample();
 
   // Check if they coincides
-  ASSERT_TRUE(state1->DebugString() != state2->DebugString());
+  ASSERT_TRUE(state1.get_as_proto().DebugString() !=
+              state2.get_as_proto().DebugString());
 }
 
 TEST(nig_prior_model, unconstrained_lpdf) {
@@ -382,7 +384,8 @@ TEST(nw_prior_model, sample) {
   auto state2 = prior->sample();
 
   // Check if they coincides
-  ASSERT_TRUE(state1->DebugString() != state2->DebugString());
+  ASSERT_TRUE(state1.get_as_proto().DebugString() !=
+              state2.get_as_proto().DebugString());
 }
 
 TEST(mnig_prior_model, set_get_hypers) {
@@ -474,5 +477,6 @@ TEST(mnig_prior_model, sample) {
   auto state2 = prior->sample();
 
   // Check if they coincides
-  ASSERT_TRUE(state1->DebugString() != state2->DebugString());
+  ASSERT_TRUE(state1.get_as_proto().DebugString() !=
+              state2.get_as_proto().DebugString());
 }


### PR DESCRIPTION
By templating the Prior over the State, we can avoid having to serialize and de-serialize to and from proto every time we sample with a SemiConjugateUpdater.

In a benchmark one-dimensional example with 2 clusters, this gives a 30% performance improvement. It is likely that the improvement will eventually be irrelevant in more challenging scenarios with multivariate data.

At the moment, only the NNIGHierarchy has been changed.