### PR TITLE
Beta Hierarchy

### DIFF
--- a/src/hierarchies/CMakeLists.txt
+++ b/src/hierarchies/CMakeLists.txt
@@ -8,6 +8,7 @@ target_sources(bayesmix
     lin_reg_uni_hierarchy.h
     fa_hierarchy.h
     lapnig_hierarchy.h
+    betagg_hierarchy.h
 )
 
 add_subdirectory(likelihoods)

--- a/src/hierarchies/betagg_hierarchy.h
+++ b/src/hierarchies/betagg_hierarchy.h
@@ -1,0 +1,42 @@
+#ifndef BAYESMIX_HIERARCHIES_BETA_GG_HIERARCHY_H_
+#define BAYESMIX_HIERARCHIES_BETA_GG_HIERARCHY_H_
+
+#include "base_hierarchy.h"
+#include "hierarchy_id.pb.h"
+#include "likelihoods/beta_likelihood.h"
+#include "priors/gamma_gamma_prior.h"
+#include "updaters/random_walk_updater.h"
+
+/**
+ *
+ */
+
+class BetaGGHierarchy
+    : public BaseHierarchy<BetaGGHierarchy, BetaLikelihood, GGPriorModel> {
+ public:
+  BetaGGHierarchy() = default;
+  ~BetaGGHierarchy() = default;
+
+  //! Returns the Protobuf ID associated to this class
+  bayesmix::HierarchyId get_id() const override {
+    return bayesmix::HierarchyId::BetaGG;
+  }
+
+  //! Sets the default updater algorithm for this hierarchy
+  void set_default_updater() {
+    updater = std::make_shared<RandomWalkUpdater>(0.1);
+  }
+
+  //! Initializes state parameters to appropriate values
+  void initialize_state() override {
+    // Get hypers
+    auto hypers = prior->get_hypers();
+    // Initialize likelihood state
+    State::ShapeRate state;
+    state.shape = hypers.a_shape / hypers.a_rate;
+    state.rate = hypers.b_shape / hypers.b_rate;
+    like->set_state(state);
+  };
+};
+
+#endif  // BAYESMIX_HIERARCHIES_BETA_GG_HIERARCHY_H_

--- a/src/hierarchies/likelihoods/CMakeLists.txt
+++ b/src/hierarchies/likelihoods/CMakeLists.txt
@@ -12,6 +12,8 @@ target_sources(bayesmix PUBLIC
     laplace_likelihood.cc
     fa_likelihood.h
     fa_likelihood.cc
+    beta_likelihood.h
+    beta_likelihood.cc
 )
 
 add_subdirectory(states)

--- a/src/hierarchies/likelihoods/beta_likelihood.cc
+++ b/src/hierarchies/likelihoods/beta_likelihood.cc
@@ -1,0 +1,30 @@
+#include "beta_likelihood.h"
+
+double BetaLikelihood::compute_lpdf(const Eigen::RowVectorXd &datum) const {
+  return stan::math::beta_lpdf(datum(0), state.shape, state.rate);
+}
+
+Eigen::VectorXd BetaLikelihood::sample() const {
+  Eigen::VectorXd out(1);
+  auto &rng = bayesmix::Rng::Instance().get();
+  out(0) = stan::math::beta_rng(state.shape, state.rate, rng);
+  out = out.cwiseMin(1.0 - 1e-8).cwiseMax(1e-8);
+  return out;
+}
+
+void BetaLikelihood::update_sum_stats(const Eigen::RowVectorXd &datum,
+                                      bool add) {
+  double x = datum(0);
+  if (add) {
+    sum_logs += std::log(x);
+    sum_logs1m += std::log(1. - x);
+  } else {
+    sum_logs -= std::log(x);
+    sum_logs1m -= std::log(1. - x);
+  }
+}
+
+void BetaLikelihood::clear_summary_statistics() {
+  sum_logs = 0;
+  sum_logs1m = 0;
+}

--- a/src/hierarchies/likelihoods/beta_likelihood.h
+++ b/src/hierarchies/likelihoods/beta_likelihood.h
@@ -1,0 +1,58 @@
+#ifndef BAYESMIX_HIERARCHIES_LIKELIHOODS_BETA_LIKELIHOOD_H_
+#define BAYESMIX_HIERARCHIES_LIKELIHOODS_BETA_LIKELIHOOD_H_
+
+#include <google/protobuf/stubs/casts.h>
+
+#include <memory>
+#include <stan/math/rev.hpp>
+#include <vector>
+
+#include "algorithm_state.pb.h"
+#include "base_likelihood.h"
+#include "states/includes.h"
+
+/**
+ * A univariate Beta likelihood, using the `State::ShapeRate` state. Represents
+ * the model:
+ *
+ * \f[
+ *    y_1,\dots,y_k \mid \mu, \sigma^2 \stackrel{\small\mathrm{iid}}{\sim}
+ * Beta(a, b),
+ * \f]
+ */
+
+class BetaLikelihood
+    : public BaseLikelihood<BetaLikelihood, State::ShapeRate> {
+ public:
+  BetaLikelihood() = default;
+  ~BetaLikelihood() = default;
+  bool is_multivariate() const override { return false; };
+  bool is_dependent() const override { return false; };
+  void clear_summary_statistics() override;
+
+  Eigen::VectorXd sample() const override;
+
+  template <typename T>
+  T cluster_lpdf_from_unconstrained(
+      const Eigen::Matrix<T, Eigen::Dynamic, 1> &unconstrained_params) const {
+    assert(unconstrained_params.size() == 2);
+
+    T a = stan::math::positive_constrain(unconstrained_params(0));
+    T b = stan::math::positive_constrain(unconstrained_params(1));
+
+    T out = 0.;
+
+    return (a - 1.) * sum_logs + (b - 1.) * sum_logs1m -
+           card * (stan::math::lgamma(a) + stan::math::lgamma(b) -
+                   stan::math::lgamma(a + b));
+  }
+
+ protected:
+  double compute_lpdf(const Eigen::RowVectorXd &datum) const override;
+  void update_sum_stats(const Eigen::RowVectorXd &datum, bool add) override;
+
+  double sum_logs = 0;
+  double sum_logs1m = 0;
+};
+
+#endif  // BAYESMIX_HIERARCHIES_LIKELIHOODS_BETA_LIKELIHOOD_H_

--- a/src/hierarchies/likelihoods/states/includes.h
+++ b/src/hierarchies/likelihoods/states/includes.h
@@ -3,6 +3,7 @@
 
 #include "fa_state.h"
 #include "multi_ls_state.h"
+#include "shape_rate_state.h"
 #include "uni_lin_reg_ls_state.h"
 #include "uni_ls_state.h"
 

--- a/src/hierarchies/likelihoods/states/shape_rate_state.h
+++ b/src/hierarchies/likelihoods/states/shape_rate_state.h
@@ -1,0 +1,88 @@
+#ifndef BAYESMIX_HIERARCHIES_LIKELIHOODS_STATES_SHAPE_RATE_STATE_H_
+#define BAYESMIX_HIERARCHIES_LIKELIHOODS_STATES_SHAPE_RATE_STATE_H_
+
+#include <memory>
+#include <stan/math/rev.hpp>
+
+#include "algorithm_state.pb.h"
+#include "base_state.h"
+#include "src/utils/proto_utils.h"
+
+namespace State {
+
+//! Returns the constrained parametrization from the
+//! unconstrained one, i.e. [in[0], exp(in[1])]
+template <typename T>
+Eigen::Matrix<T, Eigen::Dynamic, 1> shape_rate_to_constrained(
+    Eigen::Matrix<T, Eigen::Dynamic, 1> in) {
+  Eigen::Matrix<T, Eigen::Dynamic, 1> out(2);
+  out << stan::math::exp(in(0)), stan::math::exp(in(1));
+  return out;
+}
+
+//! Returns the unconstrained parametrization from the
+//! constrained one, i.e. [log(in[0]), log(in[1])]
+template <typename T>
+Eigen::Matrix<T, Eigen::Dynamic, 1> shape_rate_to_unconstrained(
+    Eigen::Matrix<T, Eigen::Dynamic, 1> in) {
+  Eigen::Matrix<T, Eigen::Dynamic, 1> out(2);
+  out << stan::math::log(in(0)), stan::math::log(in(1));
+  return out;
+}
+
+//! Returns the log determinant of the jacobian of the map
+//! (x, y) -> (log(x), log(y)), that is the inverse map of the
+//! constrained -> unconstrained representation.
+template <typename T>
+T shape_rate_log_det_jac(Eigen::Matrix<T, Eigen::Dynamic, 1> constrained) {
+  T out = 0;
+  stan::math::positive_constrain(stan::math::log(constrained(0)), out);
+  stan::math::positive_constrain(stan::math::log(constrained(1)), out);
+  return out;
+}
+
+//! A univariate shape-rate state
+//! The unconstrained representation corresponds to (log(shape), log(rate))
+class ShapeRate : public BaseState {
+ public:
+  double shape, rate;
+
+  using ProtoState = bayesmix::AlgorithmState::ClusterState;
+
+  Eigen::VectorXd get_unconstrained() const override {
+    Eigen::VectorXd temp(2);
+    temp << shape, rate;
+    return shape_rate_to_unconstrained(temp);
+  }
+
+  void set_from_unconstrained(const Eigen::VectorXd &in) override {
+    Eigen::VectorXd temp = shape_rate_to_constrained(in);
+    shape = temp(0);
+    rate = temp(1);
+  }
+
+  void set_from_proto(const ProtoState &state_, bool update_card) override {
+    if (update_card) {
+      card = state_.cardinality();
+    }
+    shape = state_.sr_state().shape();
+    rate = state_.sr_state().rate();
+  }
+
+  ProtoState get_as_proto() const override {
+    ProtoState state;
+    state.mutable_sr_state()->set_shape(shape);
+    state.mutable_sr_state()->set_rate(rate);
+    return state;
+  }
+
+  double log_det_jac() const override {
+    Eigen::VectorXd temp(2);
+    temp << shape, rate;
+    return shape_rate_log_det_jac(temp);
+  }
+};
+
+}  // namespace State
+
+#endif  // BAYESMIX_HIERARCHIES_LIKELIHOODS_STATES_SHAPE_RATE_STATE_H_

--- a/src/hierarchies/load_hierarchies.h
+++ b/src/hierarchies/load_hierarchies.h
@@ -5,6 +5,7 @@
 #include <memory>
 
 #include "abstract_hierarchy.h"
+#include "betagg_hierarchy.h"
 #include "fa_hierarchy.h"
 #include "hierarchy_id.pb.h"
 #include "lapnig_hierarchy.h"
@@ -43,6 +44,9 @@ __attribute__((constructor)) static void load_hierarchies() {
   Builder<AbstractHierarchy> LapNIGbuilder = []() {
     return std::make_shared<LapNIGHierarchy>();
   };
+  Builder<AbstractHierarchy> BetaGGbuilder = []() {
+    return std::make_shared<BetaGGHierarchy>();
+  };
 
   factory.add_builder(NNIGHierarchy().get_id(), NNIGbuilder);
   factory.add_builder(NNxIGHierarchy().get_id(), NNxIGbuilder);
@@ -50,6 +54,7 @@ __attribute__((constructor)) static void load_hierarchies() {
   factory.add_builder(LinRegUniHierarchy().get_id(), LinRegUnibuilder);
   factory.add_builder(FAHierarchy().get_id(), FAbuilder);
   factory.add_builder(LapNIGHierarchy().get_id(), LapNIGbuilder);
+  factory.add_builder(BetaGGHierarchy().get_id(), BetaGGbuilder);
 }
 
 #endif  // BAYESMIX_HIERARCHIES_LOAD_HIERARCHIES_H_

--- a/src/hierarchies/priors/CMakeLists.txt
+++ b/src/hierarchies/priors/CMakeLists.txt
@@ -13,4 +13,6 @@ target_sources(bayesmix PUBLIC
     mnig_prior_model.cc
     fa_prior_model.h
     fa_prior_model.cc
+    gamma_gamma_prior.h
+    gamma_gamma_prior.cc
 )

--- a/src/hierarchies/priors/gamma_gamma_prior.cc
+++ b/src/hierarchies/priors/gamma_gamma_prior.cc
@@ -1,0 +1,67 @@
+#include "gamma_gamma_prior.h"
+
+double GGPriorModel::lpdf(const google::protobuf::Message &state_) {
+  // Downcast state
+  auto &state = downcast_state(state_).sr_state();
+  double target = 0.;
+  target +=
+      stan::math::gamma_lpdf(state.shape(), hypers->a_shape, hypers->a_rate);
+  target +=
+      stan::math::gamma_lpdf(state.rate(), hypers->b_shape, hypers->b_rate);
+  return target;
+}
+
+State::ShapeRate GGPriorModel::sample(ProtoHypersPtr hier_hypers) {
+  // Random seed
+  auto &rng = bayesmix::Rng::Instance().get();
+
+  // Get params to use
+  auto params = get_hypers_proto()->gg_state();
+  State::ShapeRate out;
+  out.shape = stan::math::gamma_rng(params.a_shape(), params.a_rate(), rng);
+  out.rate = stan::math::gamma_rng(params.b_shape(), params.b_rate(), rng);
+  return out;
+}
+
+void GGPriorModel::update_hypers(
+    const std::vector<bayesmix::AlgorithmState::ClusterState> &states) {
+  auto &rng = bayesmix::Rng::Instance().get();
+  if (prior->has_fixed_values()) {
+    return;
+  } else {
+    throw std::invalid_argument("Unrecognized hierarchy prior");
+  }
+}
+
+void GGPriorModel::set_hypers_from_proto(
+    const google::protobuf::Message &hypers_) {
+  auto &hyperscast = downcast_hypers(hypers_).gg_state();
+  hypers->a_shape = hyperscast.a_shape();
+  hypers->a_rate = hyperscast.a_rate();
+  hypers->b_shape = hyperscast.b_shape();
+  hypers->b_rate = hyperscast.b_rate();
+}
+
+std::shared_ptr<bayesmix::AlgorithmState::HierarchyHypers>
+GGPriorModel::get_hypers_proto() const {
+  bayesmix::GamGamDistribution hypers_;
+  hypers_.set_a_shape(hypers->a_shape);
+  hypers_.set_a_rate(hypers->a_rate);
+  hypers_.set_b_shape(hypers->b_shape);
+  hypers_.set_b_rate(hypers->b_rate);
+  auto out = std::make_shared<bayesmix::AlgorithmState::HierarchyHypers>();
+  out->mutable_gg_state()->CopyFrom(hypers_);
+  return out;
+}
+
+void GGPriorModel::initialize_hypers() {
+  if (prior->has_fixed_values()) {
+    // Set values
+    hypers->a_shape = prior->fixed_values().a_shape();
+    hypers->a_rate = prior->fixed_values().a_rate();
+    hypers->b_shape = prior->fixed_values().b_shape();
+    hypers->b_rate = prior->fixed_values().b_rate();
+  } else {
+    throw std::invalid_argument("Unrecognized hierarchy prior");
+  }
+}

--- a/src/hierarchies/priors/gamma_gamma_prior.h
+++ b/src/hierarchies/priors/gamma_gamma_prior.h
@@ -1,0 +1,59 @@
+#ifndef BAYESMIX_HIERARCHIES_PRIORS_GG_PRIOR_MODEL_H_
+#define BAYESMIX_HIERARCHIES_PRIORS_GG_PRIOR_MODEL_H_
+
+#include <memory>
+#include <stan/math/rev.hpp>
+#include <vector>
+
+#include "base_prior_model.h"
+#include "hierarchy_prior.pb.h"
+#include "hyperparams.h"
+#include "src/utils/rng.h"
+
+class GGPriorModel
+    : public BasePriorModel<GGPriorModel, State::ShapeRate, Hyperparams::GG,
+                            bayesmix::GGPrior> {
+ public:
+  using AbstractPriorModel::ProtoHypers;
+  using AbstractPriorModel::ProtoHypersPtr;
+
+  GGPriorModel() = default;
+  ~GGPriorModel() = default;
+
+  double lpdf(const google::protobuf::Message &state_) override;
+
+  template <typename T>
+  T lpdf_from_unconstrained(
+      const Eigen::Matrix<T, Eigen::Dynamic, 1> &unconstrained_params) const {
+    Eigen::Matrix<T, Eigen::Dynamic, 1> constrained_params =
+        State::shape_rate_to_constrained(unconstrained_params);
+    // std::cout << "constrained_params: " << constrained_params << std::endl;
+    T log_det_jac = State::shape_rate_log_det_jac(constrained_params);
+    T shape = constrained_params(0);
+    T rate = constrained_params(1);
+    T lpdf = stan::math::gamma_lpdf(shape, hypers->a_shape, hypers->a_rate) +
+             stan::math::gamma_lpdf(rate, hypers->a_shape, hypers->a_rate);
+
+    return lpdf + log_det_jac;
+  }
+
+  State::ShapeRate sample(ProtoHypersPtr hier_hypers = nullptr) override;
+
+  void update_hypers(const std::vector<bayesmix::AlgorithmState::ClusterState>
+                         &states) override;
+
+  void set_hypers_from_proto(
+      const google::protobuf::Message &hypers_) override;
+
+  unsigned int get_dim() const { return dim; };
+
+  std::shared_ptr<bayesmix::AlgorithmState::HierarchyHypers> get_hypers_proto()
+      const override;
+
+ protected:
+  void initialize_hypers() override;
+
+  unsigned int dim;
+};
+
+#endif  // BAYESMIX_HIERARCHIES_PRIORS_GG_PRIOR_MODEL_H_

--- a/src/hierarchies/priors/hyperparams.h
+++ b/src/hierarchies/priors/hyperparams.h
@@ -31,6 +31,11 @@ struct FA {
   unsigned int q;
 };
 
+struct GG {
+  double a_shape, a_rate;
+  double b_shape, b_rate;
+};
+
 }  // namespace Hyperparams
 
 #endif  // BAYESMIX_HIERARCHIES_PRIORS_HYPERPARAMS_H_

--- a/test/likelihoods.cc
+++ b/test/likelihoods.cc
@@ -6,112 +6,13 @@
 
 #include "algorithm_state.pb.h"
 #include "ls_state.pb.h"
+#include "src/hierarchies/likelihoods/beta_likelihood.h"
 #include "src/hierarchies/likelihoods/laplace_likelihood.h"
 #include "src/hierarchies/likelihoods/multi_norm_likelihood.h"
 #include "src/hierarchies/likelihoods/uni_lin_reg_likelihood.h"
 #include "src/hierarchies/likelihoods/uni_norm_likelihood.h"
 #include "src/utils/proto_utils.h"
 #include "src/utils/rng.h"
-
-TEST(uni_norm_likelihood, set_get_state) {
-  // Instance
-  auto like = std::make_shared<UniNormLikelihood>();
-
-  // Prepare buffers
-  bayesmix::UniLSState state_;
-  bayesmix::AlgorithmState::ClusterState set_state_;
-  bayesmix::AlgorithmState::ClusterState got_state_;
-
-  // Prepare state
-  state_.set_mean(5.23);
-  state_.set_var(1.02);
-  set_state_.mutable_uni_ls_state()->CopyFrom(state_);
-
-  // Set and get the state
-  like->set_state_from_proto(set_state_);
-  like->write_state_to_proto(&got_state_);
-
-  // Check if they coincides
-  ASSERT_EQ(got_state_.DebugString(), set_state_.DebugString());
-}
-
-TEST(uni_norm_likelihood, add_remove_data) {
-  // Instance
-  auto like = std::make_shared<UniNormLikelihood>();
-
-  // Add new datum to likelihood
-  Eigen::VectorXd datum(1);
-  datum << 5.0;
-  like->add_datum(0, datum);
-
-  // Check if cardinality is augmented
-  ASSERT_EQ(like->get_card(), 1);
-
-  // Remove datum from likelihood
-  like->remove_datum(0, datum);
-
-  // Check if cardinality is reduced
-  ASSERT_EQ(like->get_card(), 0);
-}
-
-TEST(uni_norm_likelihood, eval_lpdf) {
-  // Instance
-  auto like = std::make_shared<UniNormLikelihood>();
-
-  // Set state from proto
-  bayesmix::UniLSState state_;
-  bayesmix::AlgorithmState::ClusterState clust_state_;
-  state_.set_mean(5);
-  state_.set_var(1);
-  clust_state_.mutable_uni_ls_state()->CopyFrom(state_);
-  like->set_state_from_proto(clust_state_);
-
-  // Add new datum to likelihood
-  Eigen::VectorXd data(3);
-  data << 4.5, 5.1, 2.5;
-
-  // Compute lpdf on this grid of points
-  auto evals = like->lpdf_grid(data);
-  auto like_copy = like->clone();
-  auto evals_copy = like_copy->lpdf_grid(data);
-
-  // Check if they coincides
-  ASSERT_EQ(evals, evals_copy);
-}
-
-TEST(uni_norm_likelihood, eval_lpdf_unconstrained) {
-  // Instance
-  auto like = std::make_shared<UniNormLikelihood>();
-
-  // Set state from proto
-  bayesmix::UniLSState state_;
-  bayesmix::AlgorithmState::ClusterState clust_state_;
-  double mean = 5;
-  double var = 1;
-  state_.set_mean(mean);
-  state_.set_var(var);
-  Eigen::VectorXd unconstrained_params(2);
-  unconstrained_params << mean, std::log(var);
-  clust_state_.mutable_uni_ls_state()->CopyFrom(state_);
-  like->set_state_from_proto(clust_state_);
-
-  // Add new datum to likelihood
-  Eigen::VectorXd data(3);
-  data << 4.5, 5.1, 2.5;
-  double lpdf = 0.0;
-  for (int i = 0; i < data.size(); ++i) {
-    like->add_datum(i, data.row(i));
-    lpdf += like->lpdf(data.row(i));
-  }
-
-  double clus_lpdf =
-      like->cluster_lpdf_from_unconstrained(unconstrained_params);
-  ASSERT_NEAR(lpdf, clus_lpdf, 1e-12);
-
-  unconstrained_params(0) = 4.0;
-  clus_lpdf = like->cluster_lpdf_from_unconstrained(unconstrained_params);
-  ASSERT_TRUE(std::abs(clus_lpdf - lpdf) > 1e-5);
-}
 
 TEST(multi_ls_state, set_unconstrained) {
   auto& rng = bayesmix::Rng::Instance().get();
@@ -386,6 +287,87 @@ TEST(laplace_likelihood, eval_lpdf_unconstrained) {
   ASSERT_DOUBLE_EQ(lpdf, clus_lpdf);
 
   unconstrained_params(0) = 3.0;
+  clus_lpdf = like->cluster_lpdf_from_unconstrained(unconstrained_params);
+  ASSERT_TRUE(std::abs(clus_lpdf - lpdf) > 1e-5);
+}
+
+TEST(beta_likelihood, set_get_state) {
+  // Instance
+  auto like = std::make_shared<BetaLikelihood>();
+
+  // Prepare buffers
+  bayesmix::ShapeRateState state_;
+  bayesmix::AlgorithmState::ClusterState set_state_;
+  bayesmix::AlgorithmState::ClusterState got_state_;
+
+  // Prepare state
+  state_.set_shape(5.23);
+  state_.set_rate(1.02);
+  set_state_.mutable_sr_state()->CopyFrom(state_);
+
+  // Set and get the state
+  like->set_state_from_proto(set_state_);
+  like->write_state_to_proto(&got_state_);
+
+  // Check if they coincides
+  ASSERT_EQ(got_state_.DebugString(), set_state_.DebugString());
+}
+
+TEST(beta_likelihood, eval_lpdf) {
+  // Instance
+  auto like = std::make_shared<BetaLikelihood>();
+
+  // Set state from proto
+  bayesmix::ShapeRateState state_;
+  bayesmix::AlgorithmState::ClusterState clust_state_;
+  state_.set_shape(5);
+  state_.set_rate(1);
+  clust_state_.mutable_sr_state()->CopyFrom(state_);
+  like->set_state_from_proto(clust_state_);
+
+  // Add new datum to likelihood
+  Eigen::VectorXd data(3);
+  data << 0.5, 0.6, 0.4;
+
+  // Compute lpdf on this grid of points
+  auto evals = like->lpdf_grid(data);
+  auto like_copy = like->clone();
+  auto evals_copy = like_copy->lpdf_grid(data);
+
+  // Check if they coincides
+  ASSERT_EQ(evals, evals_copy);
+}
+
+TEST(beta_likelihood, eval_lpdf_unconstrained) {
+  // Instance
+  auto like = std::make_shared<BetaLikelihood>();
+
+  // Set state from proto
+  bayesmix::ShapeRateState state_;
+  bayesmix::AlgorithmState::ClusterState clust_state_;
+  double a = 5;
+  double b = 1;
+  state_.set_shape(a);
+  state_.set_rate(b);
+  Eigen::VectorXd unconstrained_params(2);
+  unconstrained_params << std::log(a), std::log(b);
+  clust_state_.mutable_sr_state()->CopyFrom(state_);
+  like->set_state_from_proto(clust_state_);
+
+  // Add new datum to likelihood
+  Eigen::VectorXd data(3);
+  data << 0.5, 0.6, 0.4;
+  double lpdf = 0.0;
+  for (int i = 0; i < data.size(); ++i) {
+    like->add_datum(i, data.row(i));
+    lpdf += like->lpdf(data.row(i));
+  }
+
+  double clus_lpdf =
+      like->cluster_lpdf_from_unconstrained(unconstrained_params);
+  ASSERT_NEAR(lpdf, clus_lpdf, 1e-12);
+
+  unconstrained_params(0) = 4.0;
   clus_lpdf = like->cluster_lpdf_from_unconstrained(unconstrained_params);
   ASSERT_TRUE(std::abs(clus_lpdf - lpdf) > 1e-5);
 }


### PR DESCRIPTION
This PR implements a Beta mixture kernel where the parameters of the Beta distribution are given independent Gamma priors. This allows using models of the kind

```math
\begin{align*}
  y_1, \dots, y_n &\sim \int \text{Beta} ( \cdot \mid \alpha, \gamma)  P(\text{d}\alpha \, \text{d}\beta ) \\[3pt]
  P &\sim DP(\theta G_0)
\end{align*}
```
(or any variation including Pitman-Yor process, MFM, truncated stickbreaking..) where 

```math
   G_0(\text{d}\alpha \, \text{d}\beta) = \text{Gamma}(\text{d}\alpha | a_1, b_1) \text{Gamma}(\text{d}\gamma | a_2, b_2) 
```
The resulting hierarchy is not conjugate and is sampled using a simple Random Walk Updater, which works well in my experience.

Upon merging, this closes #156. 

TODO:

- [ ] Write docstrings for most of the classes
- [ ] Check why some I deleted some of the tests (LOL)